### PR TITLE
Update GitHub workflows to be up-to-date with fyne-io/fyne

### DIFF
--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -1,4 +1,3 @@
-
 name: Platform Tests
 on: [push, pull_request]
 

--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -1,3 +1,4 @@
+
 name: Platform Tests
 on: [push, pull_request]
 
@@ -5,29 +6,21 @@ jobs:
   platform_tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.12.x, 1.15.x]
+        go-version: [1.14.x, 1.17.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: WillAbides/setup-go-faster@v1.5.0
+      id: setup-go-faster
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Get dependencies
-      run: sudo apt-get update && sudo apt-get install golang gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
+      run: sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
       if: ${{ runner.os == 'Linux' }}
-
-    #- name: Verify go modules
-    #  run: |
-    #    if [ "$GO111MODULE" == "on" ]
-    #    then
-    #        # For some reason `git diff-index HEAD` does not work properly if the following line is missing.
-    #        git diff
-    #        # check that go mod tidy does not change go.mod/go.sum
-    #        go mod tidy && git diff-index --quiet HEAD -- || ( echo "go.mod/go.sum not up-to-date"; git diff-index HEAD --; false )
-    #    fi
 
     - name: Tests
       run: go test -tags ci ./...
@@ -35,7 +28,6 @@ jobs:
     - name: Update coverage
       run: |
         GO111MODULE=off go get github.com/mattn/goveralls
-
         set -e
         go test -tags ci -covermode=atomic -coverprofile=coverage.out ./...
         if [ $coverage -lt 69 ]; then echo "Test coverage lowered"; exit 1; fi
@@ -43,6 +35,8 @@ jobs:
 
     - name: Update PR Coverage
       uses: shogo82148/actions-goveralls@v1
+      env:
+        GOROOT: ${{steps.setup-go-faster.outputs.GOROOT}}
       with:
         path-to-profile: coverage.out
       if: ${{ runner.os == 'Linux' && github.event_name == 'push' }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -16,7 +16,7 @@ jobs:
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
         go install golang.org/x/lint/golint@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.2.0
+        go install honnef.co/go/tools/cmd/staticcheck@v0.2.1
 
     - name: Cleanup repository
       run: rm -rf vendor/

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -6,18 +6,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: WillAbides/setup-go-faster@v1.6.0
       with:
-        go-version: '^1.15.x'     
+        go-version: '1.16.x'     
 
     - name: Get dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install golang gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
-        GO111MODULE=off go get golang.org/x/tools/cmd/goimports                               
-        GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
-        GO111MODULE=off go get golang.org/x/lint/golint
-        GO111MODULE=off go get honnef.co/go/tools/cmd/staticcheck
+        sudo apt-get update && sudo apt-get install gcc libgl1-mesa-dev libegl1-mesa-dev libgles2-mesa-dev libx11-dev xorg-dev
+        go install golang.org/x/tools/cmd/goimports@latest
+        go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+        go install golang.org/x/lint/golint@latest
+        go install honnef.co/go/tools/cmd/staticcheck@v0.2.0
+
     - name: Cleanup repository
       run: rm -rf vendor/
 
@@ -28,10 +28,10 @@ jobs:
       run: test -z $(goimports -e -d . | tee /dev/stderr)
 
     - name: Gocyclo
-      run: gocyclo -over 50 .
+      run: gocyclo -over 30 .
 
     - name: Golint
       run: golint -set_exit_status $(go list -tags ci ./...)
 
     - name: Staticcheck
-      run: CGO_ENABLED=1 staticcheck -f stylish ./...
+      run: staticcheck -go 1.14 ./...


### PR DESCRIPTION
Workflows are rebased on top of fyne-io/fyne@dc00435 for various fixes and improvements. This also bumps the lowest Go version in tests to Go 1.14, but it will still compile with Go 1.12 until we have updated to Fyne 2.1.0 (might put up a PR for that).