### PR TITLE
Add a numerical entry, fixes #17

### DIFF
--- a/widget/numerical_entry.go
+++ b/widget/numerical_entry.go
@@ -9,16 +9,15 @@ import (
 )
 
 // NumericalEntry is an extended entry that only allows numerical input.
-// It allows integers by defaults, but floats can be enabled by setting AllowFloat.
+// Only integers are allowed by default. Support for floats can be enabled by setting AllowFloat.
 type NumericalEntry struct {
 	widget.Entry
 	AllowFloat bool
 }
 
 // NewNumericalEntry returns an extended entry that only allows numerical input.
-// The floats input parameter specifies if floating point numbers are allowed or not.
-func NewNumericalEntry(floats bool) *NumericalEntry {
-	entry := &NumericalEntry{AllowFloat: floats}
+func NewNumericalEntry() *NumericalEntry {
+	entry := &NumericalEntry{}
 	entry.ExtendBaseWidget(entry)
 	return entry
 }

--- a/widget/numerical_entry_test.go
+++ b/widget/numerical_entry_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNumericalnEntry_Int(t *testing.T) {
-	entry := NewNumericalEntry(false)
+	entry := NewNumericalEntry()
 
 	test.Type(entry, "Not a number")
 	assert.Empty(t, entry.Text)
@@ -19,7 +19,8 @@ func TestNumericalnEntry_Int(t *testing.T) {
 }
 
 func TestNumericalnEntry_Float(t *testing.T) {
-	entry := NewNumericalEntry(true)
+	entry := NewNumericalEntry()
+	entry.AllowFloat = true
 
 	test.Type(entry, "Not a number")
 	assert.Empty(t, entry.Text)


### PR DESCRIPTION
This adds an initial implementation of a numerical entry. It is partly based on the https://developer.fyne.io/tutorial/numerical-entry tutorial but expands and improves a bit on it.
Fixes #17