### PR TITLE
Update file tree to not show full path in root by default

### DIFF
--- a/widget/filetree.go
+++ b/widget/filetree.go
@@ -13,8 +13,9 @@ import (
 // FileTree extends widget.Tree to display a file system hierarchy.
 type FileTree struct {
 	widget.Tree
-	Filter storage.FileFilter
-	Sorter func(fyne.URI, fyne.URI) bool
+	Filter       storage.FileFilter
+	ShowRootPath bool
+	Sorter       func(fyne.URI, fyne.URI) bool
 
 	listableCache map[widget.TreeNodeID]fyne.ListableURI
 	uriCache      map[widget.TreeNodeID]fyne.URI
@@ -85,7 +86,7 @@ func NewFileTree(root fyne.URI) *FileTree {
 		}
 
 		var l string
-		if tree.Root == id {
+		if tree.Root == id && tree.ShowRootPath {
 			l = id
 		} else {
 			l = uri.Name()

--- a/widget/filetree_test.go
+++ b/widget/filetree_test.go
@@ -4,11 +4,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/widget"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -73,6 +76,29 @@ func TestFileTree_filter(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, tree.filter(given))
+}
+
+func TestFileTree_ShowRootPath(t *testing.T) {
+	testPath, _ := filepath.Abs("./testdata")
+	root, err := storage.ParseURI("file://" + testPath)
+	assert.NoError(t, err)
+
+	tree := NewFileTree(root)
+	firstNodeContent := func() *widget.Label {
+		renderer := tree.CreateRenderer()
+		assert.Equal(t, 1, len(renderer.Objects()))
+		content := renderer.Objects()[0].(*container.Scroll).Content.(fyne.Widget).CreateRenderer()
+		content.Layout(fyne.NewSize(100, 100))
+
+		node := content.Objects()[0].(fyne.Widget).CreateRenderer()
+		return node.Objects()[1].(*fyne.Container).Objects[0].(*widget.Label)
+	}
+
+	assert.Equal(t, "testdata", firstNodeContent().Text)
+
+	tree.ShowRootPath = true
+	tree.Refresh()
+	assert.Equal(t, "file://", firstNodeContent().Text[:7])
 }
 
 func TestFileTree_sort(t *testing.T) {


### PR DESCRIPTION
I found that the file path is usually long and mostly disappears off the tree, so just use the root name by default (like other nodes).

This can be switched back on with `FileTree.ShowRootPath = true`.