### PR TITLE
Fix rendering of transparent GIFs

### DIFF
--- a/widget/gif.go
+++ b/widget/gif.go
@@ -113,7 +113,7 @@ func (g *AnimatedGif) Start() {
 	g.runLock.Unlock()
 
 	buffer := image.NewNRGBA(g.dst.Image.Bounds())
-	draw.Draw(buffer, g.dst.Image.Bounds(), g.src.Image[0], image.Point{}, draw.Over)
+	draw.Draw(buffer, g.dst.Image.Bounds(), g.src.Image[0], image.Point{}, draw.Src)
 	g.dst.Image = buffer
 	g.dst.Refresh()
 
@@ -132,7 +132,7 @@ func (g *AnimatedGif) Start() {
 				if g.isStopping() {
 					break
 				}
-				draw.Draw(buffer, g.dst.Image.Bounds(), srcImg, image.Point{}, draw.Over)
+				draw.Draw(buffer, g.dst.Image.Bounds(), srcImg, image.Point{}, draw.Src)
 				g.dst.Refresh()
 
 				time.Sleep(time.Millisecond * time.Duration(g.src.Delay[c]) * 10)


### PR DESCRIPTION
I was using the animated GIF in my projects and noticed it was not correctly rendering GIFs with transparent sections. Further investigation showed that is was because of the use an improper [Porter-Duff operator](http://ssp.impulsetrain.com/porterduff.html#:~:text=In%20the%20Porter%2FDuff%20compositing,the%20image%20is%20partially%20there.). The operator in use before was `Over` which means on subsequent renders, transparent section would contain pixels from the previous frame. This PR is a simple fix that uses the `Src` operator instead. This ensures the new frame overwrites the previous one completely allowing transparent regions to be rendered correctly on subsequent frames.
This change will not result in any regressions because for non-transparent GIFs the two operators (`Over` & `Src`) behave essentially the same way.