### PR TITLE
Fix GIF starting and stopping

### DIFF
--- a/widget/gif.go
+++ b/widget/gif.go
@@ -160,11 +160,11 @@ func (g *AnimatedGif) Start() {
 		default:
 			g.remaining = g.src.LoopCount + 1
 		}
-
+	loop:
 		for g.remaining != 0 {
 			for c := range g.src.Image {
 				if g.isStopping() {
-					break
+					break loop
 				}
 				g.draw(buffer, c)
 
@@ -174,13 +174,18 @@ func (g *AnimatedGif) Start() {
 				g.remaining--
 			}
 		}
-
+		g.runLock.Lock()
 		g.running = false
+		g.stopping = false
+		g.runLock.Unlock()
 	}()
 }
 
 // Stop will request that the animation stops running, the last frame will remain visible
 func (g *AnimatedGif) Stop() {
+	if !g.isRunning() {
+		return
+	}
 	g.runLock.Lock()
 	g.stopping = true
 	g.runLock.Unlock()


### PR DESCRIPTION
Currently, once the GIF is stopped it can never be started again. This is because the logic for starting and stopping fails to set the `running` flag to false when stop is called. The `break` is not enough to exit the nested loop. This causes the GIF to remain in the `stopping` state forever after the `Stop()` method is called. This PR exits the nested loop correctly and sets the `running` flag to false allowing the GIF to be started again. 