### PR TITLE
Add GridWrap widget

### DIFF
--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -38,7 +38,7 @@ type GridWrap struct {
 // NewGridWrap creates and returns a GridWrap widget for displaying items in
 // a wrapping grid layout with scrolling and caching for performance.
 func NewGridWrap(length func() int, createItem func() fyne.CanvasObject, updateItem func(GridWrapItemID, fyne.CanvasObject)) *GridWrap {
-	gwList := &GridWrap{BaseWidget: widget.BaseWidget{}, Length: length, CreateItem: createItem, UpdateItem: updateItem}
+	gwList := &GridWrap{Length: length, CreateItem: createItem, UpdateItem: updateItem}
 	gwList.ExtendBaseWidget(gwList)
 	return gwList
 }

--- a/widget/gridwrap.go
+++ b/widget/gridwrap.go
@@ -102,7 +102,7 @@ func (l *GridWrap) scrollTo(id GridWrapItemID) {
 func (l *GridWrap) Resize(s fyne.Size) {
 	l.BaseWidget.Resize(s)
 	l.offsetUpdated(l.scroller.Offset)
-	l.scroller.Content.(*fyne.Container).Layout.(*GridWrapLayout).updateList(true)
+	l.scroller.Content.(*fyne.Container).Layout.(*gridWrapLayout).updateList(true)
 }
 
 // ScrollTo scrolls to the item represented by id
@@ -149,9 +149,9 @@ func (l *GridWrap) GetScrollOffset() float32 {
 }
 
 // Declare conformity with WidgetRenderer interface.
-var _ fyne.WidgetRenderer = (*GridWrapRenderer)(nil)
+var _ fyne.WidgetRenderer = (*gridWrapRenderer)(nil)
 
-type GridWrapRenderer struct {
+type gridWrapRenderer struct {
 	objects []fyne.CanvasObject
 
 	list     *GridWrap
@@ -159,41 +159,41 @@ type GridWrapRenderer struct {
 	layout   *fyne.Container
 }
 
-func newGridWrapRenderer(objects []fyne.CanvasObject, l *GridWrap, scroller *container.Scroll, layout *fyne.Container) *GridWrapRenderer {
-	lr := &GridWrapRenderer{objects: objects, list: l, scroller: scroller, layout: layout}
+func newGridWrapRenderer(objects []fyne.CanvasObject, l *GridWrap, scroller *container.Scroll, layout *fyne.Container) *gridWrapRenderer {
+	lr := &gridWrapRenderer{objects: objects, list: l, scroller: scroller, layout: layout}
 	lr.scroller.OnScrolled = l.offsetUpdated
 	return lr
 }
 
-func (l *GridWrapRenderer) Layout(size fyne.Size) {
+func (l *gridWrapRenderer) Layout(size fyne.Size) {
 	l.scroller.Resize(size)
 }
 
-func (l *GridWrapRenderer) MinSize() fyne.Size {
+func (l *gridWrapRenderer) MinSize() fyne.Size {
 	return l.scroller.MinSize().Max(l.list.itemMin)
 }
 
-func (l *GridWrapRenderer) Refresh() {
+func (l *gridWrapRenderer) Refresh() {
 	if f := l.list.CreateItem; f != nil {
 		l.list.itemMin = f().MinSize()
 	}
 	l.Layout(l.list.Size())
 	l.scroller.Refresh()
-	l.layout.Layout.(*GridWrapLayout).updateList(true)
+	l.layout.Layout.(*gridWrapLayout).updateList(true)
 	canvas.Refresh(l.list)
 }
 
-func (l *GridWrapRenderer) Destroy() {
+func (l *gridWrapRenderer) Destroy() {
 }
 
-func (l *GridWrapRenderer) Objects() []fyne.CanvasObject {
+func (l *gridWrapRenderer) Objects() []fyne.CanvasObject {
 	return l.objects
 }
 
 // Declare conformity with Layout interface.
-var _ fyne.Layout = (*GridWrapLayout)(nil)
+var _ fyne.Layout = (*gridWrapLayout)(nil)
 
-type GridWrapLayout struct {
+type gridWrapLayout struct {
 	list     *GridWrap
 	children []fyne.CanvasObject
 
@@ -203,16 +203,16 @@ type GridWrapLayout struct {
 }
 
 func newGridWrapLayout(list *GridWrap) fyne.Layout {
-	l := &GridWrapLayout{list: list, itemPool: &syncPool{}, visible: make(map[GridWrapItemID]fyne.CanvasObject)}
+	l := &gridWrapLayout{list: list, itemPool: &syncPool{}, visible: make(map[GridWrapItemID]fyne.CanvasObject)}
 	list.offsetUpdated = l.offsetUpdated
 	return l
 }
 
-func (l *GridWrapLayout) Layout([]fyne.CanvasObject, fyne.Size) {
+func (l *gridWrapLayout) Layout([]fyne.CanvasObject, fyne.Size) {
 	l.updateList(true)
 }
 
-func (l *GridWrapLayout) MinSize([]fyne.CanvasObject) fyne.Size {
+func (l *gridWrapLayout) MinSize([]fyne.CanvasObject) fyne.Size {
 	if lenF := l.list.Length; lenF != nil {
 		cols := l.list.getColCount()
 		rows := float32(math.Ceil(float64(lenF()) / float64(cols)))
@@ -222,7 +222,7 @@ func (l *GridWrapLayout) MinSize([]fyne.CanvasObject) fyne.Size {
 	return fyne.NewSize(0, 0)
 }
 
-func (l *GridWrapLayout) getItem() fyne.CanvasObject {
+func (l *gridWrapLayout) getItem() fyne.CanvasObject {
 	item := l.itemPool.Obtain()
 	if item == nil {
 		if f := l.list.CreateItem; f != nil {
@@ -232,7 +232,7 @@ func (l *GridWrapLayout) getItem() fyne.CanvasObject {
 	return item
 }
 
-func (l *GridWrapLayout) offsetUpdated(pos fyne.Position) {
+func (l *gridWrapLayout) offsetUpdated(pos fyne.Position) {
 	if l.list.offsetY == pos.Y {
 		return
 	}
@@ -240,7 +240,7 @@ func (l *GridWrapLayout) offsetUpdated(pos fyne.Position) {
 	l.updateList(false)
 }
 
-func (l *GridWrapLayout) setupListItem(li fyne.CanvasObject, id GridWrapItemID) {
+func (l *gridWrapLayout) setupListItem(li fyne.CanvasObject, id GridWrapItemID) {
 	if f := l.list.UpdateItem; f != nil {
 		f(id, li)
 	}
@@ -255,7 +255,7 @@ func (l *GridWrap) getColCount() int {
 	return colCount
 }
 
-func (l *GridWrapLayout) updateList(refresh bool) {
+func (l *gridWrapLayout) updateList(refresh bool) {
 	// code here is a mashup of listLayout.updateList and gridWrapLayout.Layout
 
 	l.renderLock.Lock()

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -95,7 +95,7 @@ func createGridWrap(items int) *GridWrap {
 			return icon
 		},
 		func(id GridWrapItemID, item fyne.CanvasObject) {
-			item.(*widget.Icon).Resource = data[id]
+			item.(*widget.Icon).SetResource(data[id])
 		},
 	)
 	list.Resize(fyne.NewSize(200, 400))

--- a/widget/gridwrap_test.go
+++ b/widget/gridwrap_test.go
@@ -1,0 +1,103 @@
+package widget
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGridWrap_New(t *testing.T) {
+	g := createGridWrap(1000)
+	template := widget.NewIcon(theme.AccountIcon())
+
+	assert.Equal(t, 1000, g.Length())
+	assert.GreaterOrEqual(t, g.MinSize().Width, template.MinSize().Width)
+	assert.Equal(t, float32(0), g.offsetY)
+}
+
+func TestGridWrap_OffsetChange(t *testing.T) {
+	g := createGridWrap(1000)
+
+	assert.Equal(t, float32(0), g.offsetY)
+
+	g.scroller.Scrolled(&fyne.ScrollEvent{Scrolled: fyne.NewDelta(0, -280)})
+
+	assert.NotEqual(t, 0, g.offsetY)
+}
+
+func TestGridWrap_ScrollTo(t *testing.T) {
+	g := createGridWrap(1000)
+
+	// override update item to keep track of greatest item rendered
+	oldUpdateFunc := g.UpdateItem
+	var greatest GridWrapItemID = -1
+	g.UpdateItem = func(id GridWrapItemID, item fyne.CanvasObject) {
+		if id > greatest {
+			greatest = id
+		}
+		oldUpdateFunc(id, item)
+	}
+
+	g.ScrollTo(650)
+	assert.GreaterOrEqual(t, greatest, 650)
+
+	g.ScrollTo(800)
+	assert.GreaterOrEqual(t, greatest, 800)
+
+	g.ScrollToBottom()
+	assert.Equal(t, greatest, GridWrapItemID(999))
+}
+
+func TestGridWrap_ScrollToTop(t *testing.T) {
+	g := createGridWrap(1000)
+	g.ScrollTo(750)
+	assert.NotEqual(t, g.offsetY, float32(0))
+	g.ScrollToTop()
+	assert.Equal(t, g.offsetY, float32(0))
+}
+
+func createGridWrap(items int) *GridWrap {
+	data := make([]fyne.Resource, items)
+	for i := 0; i < items; i++ {
+		switch i % 10 {
+		case 0:
+			data[i] = theme.AccountIcon()
+		case 1:
+			data[i] = theme.CancelIcon()
+		case 2:
+			data[i] = theme.CheckButtonIcon()
+		case 3:
+			data[i] = theme.FileApplicationIcon()
+		case 4:
+			data[i] = theme.FileVideoIcon()
+		case 5:
+			data[i] = theme.DocumentIcon()
+		case 6:
+			data[i] = theme.MediaPlayIcon()
+		case 7:
+			data[i] = theme.MediaRecordIcon()
+		case 8:
+			data[i] = theme.FolderIcon()
+		case 9:
+			data[i] = theme.FolderOpenIcon()
+		}
+	}
+
+	list := NewGridWrap(
+		func() int {
+			return len(data)
+		},
+		func() fyne.CanvasObject {
+			icon := widget.NewIcon(theme.DocumentIcon())
+			return icon
+		},
+		func(id GridWrapItemID, item fyne.CanvasObject) {
+			item.(*widget.Icon).Resource = data[id]
+		},
+	)
+	list.Resize(fyne.NewSize(200, 400))
+	return list
+}

--- a/widget/gridwraplist.go
+++ b/widget/gridwraplist.go
@@ -1,0 +1,355 @@
+package widget
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/data/binding"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+)
+
+// Declare conformity with Widget interface.
+var _ fyne.Widget = (*GridWrapList)(nil)
+
+// GridWrapListItemID is the ID of an individual item in the GridWrapList widget.
+type GridWrapListItemID int
+
+// GridWrapList is a widget with an API very similar to widget.List,
+// that lays out items in a wrapping grid similar to container.NewGridWrap.
+// It caches and reuses widgets for performance.
+type GridWrapList struct {
+	widget.BaseWidget
+
+	Length     func() int                                          `json:"-"`
+	CreateItem func() fyne.CanvasObject                            `json:"-"`
+	UpdateItem func(id GridWrapListItemID, item fyne.CanvasObject) `json:"-"`
+
+	scroller      *container.Scroll
+	itemMin       fyne.Size
+	offsetY       float32
+	offsetUpdated func(fyne.Position)
+}
+
+// NewGridWrapList creates and returns a GridWrapList widget for displaying items in
+// a wrapping grid layout with scrolling and caching for performance.
+func NewGridWrapList(length func() int, createItem func() fyne.CanvasObject, updateItem func(GridWrapListItemID, fyne.CanvasObject)) *GridWrapList {
+	gwList := &GridWrapList{BaseWidget: widget.BaseWidget{}, Length: length, CreateItem: createItem, UpdateItem: updateItem}
+	gwList.ExtendBaseWidget(gwList)
+	return gwList
+}
+
+// NewGridWrapListWithData creates a new GridWrapList widget that will display the contents of the provided data.
+func NewGridWrapListWithData(data binding.DataList, createItem func() fyne.CanvasObject, updateItem func(binding.DataItem, fyne.CanvasObject)) *GridWrapList {
+	gwList := NewGridWrapList(
+		data.Length,
+		createItem,
+		func(i GridWrapListItemID, o fyne.CanvasObject) {
+			item, err := data.GetItem(int(i))
+			if err != nil {
+				fyne.LogError(fmt.Sprintf("Error getting data item %d", i), err)
+				return
+			}
+			updateItem(item, o)
+		})
+
+	data.AddListener(binding.NewDataListener(gwList.Refresh))
+	return gwList
+}
+
+// CreateRenderer is a private method to Fyne which links this widget to its renderer.
+func (l *GridWrapList) CreateRenderer() fyne.WidgetRenderer {
+	l.ExtendBaseWidget(l)
+
+	if f := l.CreateItem; f != nil {
+		if l.itemMin.IsZero() {
+			l.itemMin = f().MinSize()
+		}
+	}
+	layout := &fyne.Container{}
+	l.scroller = container.NewVScroll(layout)
+	layout.Layout = newGridWrapListLayout(l)
+	layout.Resize(layout.MinSize())
+	objects := []fyne.CanvasObject{l.scroller}
+	lr := newGridWrapListRenderer(objects, l, l.scroller, layout)
+	return lr
+}
+
+// MinSize returns the size that this widget should not shrink below.
+func (l *GridWrapList) MinSize() fyne.Size {
+	l.ExtendBaseWidget(l)
+
+	return l.BaseWidget.MinSize()
+}
+
+func (l *GridWrapList) scrollTo(id GridWrapListItemID) {
+	if l.scroller == nil {
+		return
+	}
+	row := math.Floor(float64(id) / float64(l.getColCount()))
+	y := (float32(row) * l.itemMin.Height) + (float32(row) * theme.Padding())
+	if y < l.scroller.Offset.Y {
+		l.scroller.Offset.Y = y
+	} else if y+l.itemMin.Height > l.scroller.Offset.Y+l.scroller.Size().Height {
+		l.scroller.Offset.Y = y + l.itemMin.Height - l.scroller.Size().Height
+	}
+	l.offsetUpdated(l.scroller.Offset)
+}
+
+// Resize is called when this GridWrapList should change size. We refresh to ensure invisible items are drawn.
+func (l *GridWrapList) Resize(s fyne.Size) {
+	l.BaseWidget.Resize(s)
+	l.offsetUpdated(l.scroller.Offset)
+	l.scroller.Content.(*fyne.Container).Layout.(*gridWrapListLayout).updateList(true)
+}
+
+// ScrollTo scrolls to the item represented by id
+func (l *GridWrapList) ScrollTo(id GridWrapListItemID) {
+	length := 0
+	if f := l.Length; f != nil {
+		length = f()
+	}
+	if id < 0 || int(id) >= length {
+		return
+	}
+	l.scrollTo(id)
+	l.Refresh()
+}
+
+// ScrollToBottom scrolls to the end of the list
+func (l *GridWrapList) ScrollToBottom() {
+	length := 0
+	if f := l.Length; f != nil {
+		length = f()
+	}
+	if length > 0 {
+		length--
+	}
+	l.scrollTo(GridWrapListItemID(length))
+	l.Refresh()
+}
+
+// ScrollToTop scrolls to the start of the list
+func (l *GridWrapList) ScrollToTop() {
+	l.scrollTo(0)
+	l.Refresh()
+}
+
+// ScrollToOffset scrolls the list to the given offset position
+func (l *GridWrapList) ScrollToOffset(offset float32) {
+	l.scroller.Offset.Y = offset
+	l.offsetUpdated(l.scroller.Offset)
+}
+
+// GetScrollOffset returns the current scroll offset position
+func (l *GridWrapList) GetScrollOffset() float32 {
+	return l.offsetY
+}
+
+// Declare conformity with WidgetRenderer interface.
+var _ fyne.WidgetRenderer = (*gridWrapListRenderer)(nil)
+
+type gridWrapListRenderer struct {
+	objects []fyne.CanvasObject
+
+	list     *GridWrapList
+	scroller *container.Scroll
+	layout   *fyne.Container
+}
+
+func newGridWrapListRenderer(objects []fyne.CanvasObject, l *GridWrapList, scroller *container.Scroll, layout *fyne.Container) *gridWrapListRenderer {
+	lr := &gridWrapListRenderer{objects: objects, list: l, scroller: scroller, layout: layout}
+	lr.scroller.OnScrolled = l.offsetUpdated
+	return lr
+}
+
+func (l *gridWrapListRenderer) Layout(size fyne.Size) {
+	l.scroller.Resize(size)
+}
+
+func (l *gridWrapListRenderer) MinSize() fyne.Size {
+	return l.scroller.MinSize().Max(l.list.itemMin)
+}
+
+func (l *gridWrapListRenderer) Refresh() {
+	if f := l.list.CreateItem; f != nil {
+		l.list.itemMin = f().MinSize()
+	}
+	l.Layout(l.list.Size())
+	l.scroller.Refresh()
+	l.layout.Layout.(*gridWrapListLayout).updateList(true)
+	canvas.Refresh(l.list)
+}
+
+func (l *gridWrapListRenderer) Destroy() {
+}
+
+func (l *gridWrapListRenderer) Objects() []fyne.CanvasObject {
+	return l.objects
+}
+
+func (r *gridWrapListRenderer) SetObjects(objects []fyne.CanvasObject) {
+	r.objects = objects
+}
+
+// Declare conformity with Layout interface.
+var _ fyne.Layout = (*gridWrapListLayout)(nil)
+
+type gridWrapListLayout struct {
+	list     *GridWrapList
+	children []fyne.CanvasObject
+
+	itemPool   *syncPool
+	visible    map[GridWrapListItemID]fyne.CanvasObject
+	renderLock sync.Mutex
+}
+
+func newGridWrapListLayout(list *GridWrapList) fyne.Layout {
+	l := &gridWrapListLayout{list: list, itemPool: &syncPool{}, visible: make(map[GridWrapListItemID]fyne.CanvasObject)}
+	list.offsetUpdated = l.offsetUpdated
+	return l
+}
+
+func (l *gridWrapListLayout) Layout([]fyne.CanvasObject, fyne.Size) {
+	l.updateList(true)
+}
+
+func (l *gridWrapListLayout) MinSize([]fyne.CanvasObject) fyne.Size {
+	if lenF := l.list.Length; lenF != nil {
+		cols := l.list.getColCount()
+		rows := float32(math.Ceil(float64(lenF()) / float64(cols)))
+		return fyne.NewSize(l.list.itemMin.Width,
+			(l.list.itemMin.Height+theme.Padding())*rows-theme.Padding())
+	}
+	return fyne.NewSize(0, 0)
+}
+
+func (l *gridWrapListLayout) getItem() fyne.CanvasObject {
+	item := l.itemPool.Obtain()
+	if item == nil {
+		if f := l.list.CreateItem; f != nil {
+			item = f()
+		}
+	}
+	return item
+}
+
+func (l *gridWrapListLayout) offsetUpdated(pos fyne.Position) {
+	if l.list.offsetY == pos.Y {
+		return
+	}
+	l.list.offsetY = pos.Y
+	l.updateList(false)
+}
+
+func (l *gridWrapListLayout) setupListItem(li fyne.CanvasObject, id GridWrapListItemID) {
+	if f := l.list.UpdateItem; f != nil {
+		f(id, li)
+	}
+}
+
+func (l *GridWrapList) getColCount() int {
+	colCount := 1
+	width := l.Size().Width
+	if width > l.itemMin.Width {
+		colCount = int(math.Floor(float64(width+theme.Padding()) / float64(l.itemMin.Width+theme.Padding())))
+	}
+	return colCount
+}
+
+func (l *gridWrapListLayout) updateList(refresh bool) {
+	// code here is a mashup of listLayout.updateList and gridWrapLayout.Layout
+
+	l.renderLock.Lock()
+	defer l.renderLock.Unlock()
+	length := 0
+	if f := l.list.Length; f != nil {
+		length = f()
+	}
+
+	colCount := l.list.getColCount()
+	visibleRowsCount := int(math.Ceil(float64(l.list.scroller.Size().Height)/float64(l.list.itemMin.Height+theme.Padding()))) + 1
+
+	offY := l.list.offsetY - float32(math.Mod(float64(l.list.offsetY), float64(l.list.itemMin.Height+theme.Padding())))
+	minRow := int(offY / (l.list.itemMin.Height + theme.Padding()))
+	minItem := GridWrapListItemID(minRow * colCount)
+	maxRow := int(math.Min(float64(minRow+visibleRowsCount), math.Ceil(float64(length)/float64(colCount))))
+	maxItem := GridWrapListItemID(math.Min(float64(maxRow*colCount), float64(length-1)))
+
+	if l.list.UpdateItem == nil {
+		fyne.LogError("Missing UpdateCell callback required for GridWrapList", nil)
+	}
+
+	wasVisible := l.visible
+	l.visible = make(map[GridWrapListItemID]fyne.CanvasObject)
+	var cells []fyne.CanvasObject
+	y := offY
+	curItem := minItem
+	for row := minRow; row <= maxRow && curItem <= maxItem; row++ {
+		x := float32(0)
+		for col := 0; col < colCount && curItem <= maxItem; col++ {
+			c, ok := wasVisible[curItem]
+			if !ok {
+				c = l.getItem()
+				if c == nil {
+					continue
+				}
+				c.Resize(l.list.itemMin)
+				l.setupListItem(c, curItem)
+			}
+
+			c.Move(fyne.NewPos(x, y))
+			if refresh {
+				c.Resize(l.list.itemMin)
+				if ok { // refresh visible
+					l.setupListItem(c, curItem)
+				}
+			}
+
+			x += l.list.itemMin.Width + theme.Padding()
+			l.visible[curItem] = c
+			cells = append(cells, c)
+			curItem++
+		}
+		y += l.list.itemMin.Height + theme.Padding()
+	}
+
+	for id, old := range wasVisible {
+		if _, ok := l.visible[id]; !ok {
+			l.itemPool.Release(old)
+		}
+	}
+	l.children = cells
+
+	objects := l.children
+	l.list.scroller.Content.(*fyne.Container).Objects = objects
+}
+
+type pool interface {
+	Obtain() fyne.CanvasObject
+	Release(fyne.CanvasObject)
+}
+
+var _ pool = (*syncPool)(nil)
+
+type syncPool struct {
+	sync.Pool
+}
+
+// Obtain returns an item from the pool for use
+func (p *syncPool) Obtain() (item fyne.CanvasObject) {
+	o := p.Get()
+	if o != nil {
+		item = o.(fyne.CanvasObject)
+	}
+	return
+}
+
+// Release adds an item into the pool to be used later
+func (p *syncPool) Release(item fyne.CanvasObject) {
+	p.Put(item)
+}


### PR DESCRIPTION
This is a port from fyne to fyne-x of the GridWrapList component I made for [Supersonic](https://github.com/dweymouth/supersonic) used for the album grid view. I stripped out the use of private APIs (`internal/widget/scroll`, `BaseWidget.super()`) and copied others (`syncPool`).