### PR TITLE
ResponsiveCanvasObject interface + object hiding

### DIFF
--- a/layout/responsive.go
+++ b/layout/responsive.go
@@ -250,6 +250,8 @@ type ResponsiveCanvasObject interface {
 	// ComputeWindowResize calculates, resizes and returns the object size
 	// based on the window resizing to a new width. Returns 0 if not visible
 	ComputeWindowResize(windowSize, containerSize fyne.Size) fyne.Size
+	// Configure whether the element should be hidden at each breakpoint
+	Hidable(hiddenAtBreakpoint ...bool)
 }
 
 type responsiveWidget struct {
@@ -317,6 +319,7 @@ func (ro *responsiveWidget) hideOnResize(windowSize fyne.Size) {
 }
 
 func (ro *responsiveWidget) ComputeWindowResize(windowSize, containerSize fyne.Size) fyne.Size {
+	ro.hideOnResize(windowSize)
 	if !ro.Visible() {
 		return fyne.Size{0, 0}
 	}

--- a/layout/responsive_test.go
+++ b/layout/responsive_test.go
@@ -69,8 +69,8 @@ func TestResponsive_HidableResponsive(t *testing.T) {
 	padding := theme.Padding()
 
 	// build
-	label1 := Responsive(widget.NewLabel("Hello World"), 1, .5)
-	label2 := Responsive(widget.NewLabel("Hello World"), 1, .5)
+	label1 := HidableResponsive(widget.NewLabel("Hello World"), 1, .5)
+	label2 := HidableResponsive(widget.NewLabel("Hello World"), 1, .5)
 	label2.Hidable(true, false)
 
 	win := test.NewWindow(

--- a/layout/responsive_test.go
+++ b/layout/responsive_test.go
@@ -63,6 +63,40 @@ func TestResponsive_Responsive(t *testing.T) {
 	assert.Equal(t, w/2-padding*2, size2.Width)
 }
 
+// Test is a basic responsive layout is correctly configured. This test 2 widgets
+// with 100% for small size and 50% for medium size or taller.
+func TestResponsive_HidableResponsive(t *testing.T) {
+	padding := theme.Padding()
+
+	// build
+	label1 := Responsive(widget.NewLabel("Hello World"), 1, .5)
+	label2 := Responsive(widget.NewLabel("Hello World"), 1, .5)
+	label2.Hidable(true, false)
+
+	win := test.NewWindow(
+		NewResponsiveLayout(label1, label2),
+	)
+	win.SetPadded(true)
+	defer win.Close()
+
+	// First, we are at w < SMALL so the labels should be sized to 100% of the layout
+	w, h := float32(SMALL), float32(300)
+	win.Resize(fyne.NewSize(w, h))
+	size1 := label1.Size()
+	size2 := label2.Size()
+	assert.Equal(t, w-padding*2, size1.Width)
+	assert.Equal(t, float32(0), size2.Width)
+
+	// Then resize to w > SMALL so the labels should be sized to 50% of the layout
+	w = float32(MEDIUM)
+	win.Resize(fyne.NewSize(w, h))
+	size1 = label1.Size()
+	size2 = label2.Size()
+	// remove 2 * padding as there is 2 objects in a line
+	assert.Equal(t, w/2-padding*2, size1.Width)
+	assert.Equal(t, w/2-padding*2, size2.Width)
+}
+
 // Check if a widget that overflows the container goes to the next line.
 func TestResponsive_GoToNextLine(t *testing.T) {
 	w, h := float32(200), float32(300)


### PR DESCRIPTION
Two changes,

- Interface for ResponsiveCanvasObject so that custom types can be used
- Resizing behavior is handled by the interface method
- Add hiding behavior so object can be hidden if the window shrinks

First two are self explanatory. The hiding behavior is something that I personally wanted so I can have a "summary/detail" view in a table widget I will am working on.

Let me know if you think I should move the hiding behavior out into another interface.