### PR TITLE
Add a portion layout with percentage pased sizes

### DIFF
--- a/layout/portion.go
+++ b/layout/portion.go
@@ -37,18 +37,30 @@ func (p *HPortion) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		return fyne.NewSize(0, 0)
 	}
 
-	size := fyne.Size{}
-	for _, item := range objects {
-		min := item.MinSize()
-		size.Width += min.Width
-		size.Height = fyne.Max(size.Height, min.Height)
+	if len(objects) == 0 {
+		return fyne.NewSize(0, 0)
 	}
 
-	return size
+	maxMinWidth := float32(0)
+	maxIndex := -1
+	height := float32(0)
+
+	for i := 0; i < len(objects); i++ {
+		min := objects[i].MinSize()
+		height = fyne.Max(height, min.Height)
+
+		if min.Width > maxMinWidth {
+			maxMinWidth = min.Width
+			maxIndex = i
+		}
+	}
+
+	return fyne.NewSize(maxMinWidth/p.Portions[maxIndex], height)
 }
 
 // NewHPortion creates a layout that partitions objects verticaly taking up
 // as large of a portion of the space as defined by the given slice.
+// The portions should be between 0 and 1 but not equal to.
 // The length of the Portions slice needs to be equal to the amount of objects.
 func NewHPortion(Portions []float32) *HPortion {
 	return &HPortion{Portions: Portions}
@@ -84,18 +96,30 @@ func (p *VPortion) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		return fyne.NewSize(0, 0)
 	}
 
-	size := fyne.Size{}
-	for _, item := range objects {
-		min := item.MinSize()
-		size.Width = fyne.Max(size.Width, min.Width)
-		size.Height += min.Height
+	if len(objects) == 0 {
+		return fyne.NewSize(0, 0)
 	}
 
-	return size
+	maxMinHeight := float32(0)
+	maxIndex := -1
+	width := float32(0)
+
+	for i := 0; i < len(objects); i++ {
+		min := objects[i].MinSize()
+		width = fyne.Max(width, min.Width)
+
+		if min.Height > maxMinHeight {
+			maxMinHeight = min.Height
+			maxIndex = i
+		}
+	}
+
+	return fyne.NewSize(width, maxMinHeight/p.Portions[maxIndex])
 }
 
 // NewVPortion creates a layout that partitions objects verticaly taking up
 // as large of a portion of the space as defined by the given slice.
+// The portions should be between 0 and 1 but not equal to.
 // The length of the Portions slice needs to be equal to the amount of objects.
 func NewVPortion(portion []float32) *VPortion {
 	return &VPortion{Portions: portion}

--- a/layout/portion.go
+++ b/layout/portion.go
@@ -19,7 +19,7 @@ func (p *HPortion) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		return
 	}
 
-	padding := theme.InnerPadding()
+	padding := theme.Padding()
 	xpos := padding
 
 	for i, child := range objects {
@@ -55,7 +55,8 @@ func (p *HPortion) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 	}
 
-	return fyne.NewSize(maxMinWidth/p.Portions[maxIndex], height)
+	totalPadding := float32(len(objects)-1) * theme.Padding()
+	return fyne.NewSize(maxMinWidth/p.Portions[maxIndex]+totalPadding, height)
 }
 
 // NewHPortion creates a layout that partitions objects verticaly taking up
@@ -78,7 +79,7 @@ func (p *VPortion) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 		return
 	}
 
-	padding := theme.InnerPadding()
+	padding := theme.Padding()
 	ypos := padding
 
 	for i, child := range objects {
@@ -114,7 +115,8 @@ func (p *VPortion) MinSize(objects []fyne.CanvasObject) fyne.Size {
 		}
 	}
 
-	return fyne.NewSize(width, maxMinHeight/p.Portions[maxIndex])
+	totalPadding := float32(len(objects)-1) * theme.Padding()
+	return fyne.NewSize(width, maxMinHeight/p.Portions[maxIndex]+totalPadding)
 }
 
 // NewVPortion creates a layout that partitions objects verticaly taking up

--- a/layout/portion.go
+++ b/layout/portion.go
@@ -1,0 +1,102 @@
+package layout
+
+import (
+	"log"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+var _ fyne.Layout = (*HPortion)(nil)
+
+type HPortion struct {
+	Portions []float32
+}
+
+func (p *HPortion) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	if len(p.Portions) != len(objects) {
+		log.Println("Mismatch between partitions and objects")
+		return
+	}
+
+	padding := theme.InnerPadding()
+	xpos := padding
+
+	for i, child := range objects {
+		width := p.Portions[i] * size.Width
+		child.Resize(fyne.NewSize(width, size.Height))
+		child.Move(fyne.NewPos(xpos, 0))
+
+		xpos += width + padding
+	}
+}
+
+func (p *HPortion) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	if len(p.Portions) != len(objects) {
+		log.Println("Mismatch between partitions and objects")
+		return fyne.NewSize(0, 0)
+	}
+
+	size := fyne.Size{}
+	for _, item := range objects {
+		min := item.MinSize()
+		size.Width += min.Width
+		size.Height = fyne.Max(size.Height, min.Height)
+	}
+
+	return size
+}
+
+// NewHPortion creates a layout that partitions objects verticaly taking up
+// as large of a portion of the space as defined by the given slice.
+// The length of the Portions slice needs to be equal to the amount of objects.
+func NewHPortion(Portions []float32) *HPortion {
+	return &HPortion{Portions: Portions}
+}
+
+var _ fyne.Layout = (*VPortion)(nil)
+
+type VPortion struct {
+	Portions []float32
+}
+
+func (p *VPortion) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	if len(p.Portions) != len(objects) {
+		log.Println("Mismatch between partitions and objects")
+		return
+	}
+
+	padding := theme.InnerPadding()
+	ypos := padding
+
+	for i, child := range objects {
+		height := p.Portions[i] * size.Height
+		child.Resize(fyne.NewSize(ypos, height))
+		child.Move(fyne.NewPos(ypos, 0))
+
+		ypos += height + padding
+	}
+}
+
+func (p *VPortion) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	if len(p.Portions) != len(objects) {
+		log.Println("Mismatch between partitions and objects")
+		return fyne.NewSize(0, 0)
+	}
+
+	size := fyne.Size{}
+	for _, item := range objects {
+		min := item.MinSize()
+		size.Width = fyne.Max(size.Width, min.Width)
+		size.Height += min.Height
+	}
+
+	return size
+}
+
+// NewVPortion creates a layout that partitions objects verticaly taking up
+// as large of a portion of the space as defined by the given slice.
+// The length of the Portions slice needs to be equal to the amount of objects.
+func NewVPortion(portion []float32) *VPortion {
+	return &VPortion{Portions: portion}
+}


### PR DESCRIPTION
This is a WIP layout to allow a space to be divided up into portions based on percentages in a slice. The example below contains four buttons that are set to take up 30%, 20%, 30% and 10% respectively (with remaining 10% empty at the end).

[Screencast from 2023-06-18 13-56-34.webm](https://github.com/fyne-io/fyne-x/assets/25466657/c2f3f912-091d-46f2-85c4-e5f1915c1869)
