### PR TITLE
Add different selection modes to Calendar (Single, Multi, Range)

### DIFF
--- a/cmd/calendar_demo/main.go
+++ b/cmd/calendar_demo/main.go
@@ -15,15 +15,17 @@ func main() {
 	a := app.New()
 	w := a.NewWindow("Calendar")
 
-	i := widget.NewLabel("Please Choose a Date")
+	i := widget.NewLabel("OnChanged")
 	i.Alignment = fyne.TextAlignCenter
 	l := widget.NewLabel("")
 	l.Alignment = fyne.TextAlignCenter
-	d := &date{instruction: i, dateChosen: l}
+	ll := widget.NewLabel("OnSelected: ")
+	d := &date{selectedDates: l, dateSelected: ll}
 
 	// Defines which date you would like the calendar to start
 	startingDate := time.Now()
-	calendar := xwidget.NewCalendar(startingDate, d.onChanged)
+	calendar := xwidget.NewCalendarWithMode(startingDate, d.onChanged, xwidget.CalendarSingle)
+	calendar.OnSelected = d.onSelected
 
 	selection := widget.NewRadioGroup([]string{"Single", "Multi", "Range"}, func(s string) {
 		calendar.ClearSelection()
@@ -47,6 +49,7 @@ func main() {
 	c := container.NewVBox(
 		i,
 		scroll,
+		ll,
 		calendar,
 		selection,
 	)
@@ -56,16 +59,19 @@ func main() {
 }
 
 type date struct {
-	instruction *widget.Label
-	dateChosen  *widget.Label
+	selectedDates *widget.Label
+	dateSelected  *widget.Label
 }
 
 func (d *date) onChanged(selectedDates []time.Time) {
 	// use time object to set text on label with given format
-	d.instruction.SetText("Date Selected:")
 	var str string
 	for _, d := range selectedDates {
 		str += fmt.Sprint(d.Format("Mon 02 Jan 2006"), "\n")
 	}
-	d.dateChosen.SetText(str)
+	d.selectedDates.SetText(str)
+}
+
+func (d *date) onSelected(selectedDate time.Time) {
+	d.dateSelected.SetText("OnSelected: " + selectedDate.Format("Mon 02 Jan 2006"))
 }

--- a/cmd/calendar_demo/main.go
+++ b/cmd/calendar_demo/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -22,9 +23,33 @@ func main() {
 
 	// Defines which date you would like the calendar to start
 	startingDate := time.Now()
-	calendar := xwidget.NewCalendar(startingDate, d.onSelected)
+	calendar := xwidget.NewCalendar(startingDate, xwidget.CalendarSingle, d.onChanged)
 
-	c := container.NewVBox(i, l, calendar)
+	selection := widget.NewRadioGroup([]string{"Single", "Multi", "Range"}, func(s string) {
+		calendar.ClearSelection()
+		switch s {
+		case "Single":
+			calendar.SelectionMode = xwidget.CalendarSingle
+		case "Multi":
+			calendar.SelectionMode = xwidget.CalendarMulti
+		case "Range":
+			calendar.SelectionMode = xwidget.CalendarRange
+		}
+		calendar.Refresh()
+	})
+	selection.Horizontal = true
+	selection.Required = true
+	selection.Selected = "Single"
+
+	scroll := container.NewVScroll(l)
+	scroll.SetMinSize(fyne.NewSize(200, 100))
+
+	c := container.NewVBox(
+		i,
+		scroll,
+		calendar,
+		selection,
+	)
 
 	w.SetContent(c)
 	w.ShowAndRun()
@@ -35,8 +60,12 @@ type date struct {
 	dateChosen  *widget.Label
 }
 
-func (d *date) onSelected(t time.Time) {
+func (d *date) onChanged(selectedDates []time.Time) {
 	// use time object to set text on label with given format
 	d.instruction.SetText("Date Selected:")
-	d.dateChosen.SetText(t.Format("Mon 02 Jan 2006"))
+	var str string
+	for _, d := range selectedDates {
+		str += fmt.Sprint(d.Format("Mon 02 Jan 2006"), "\n")
+	}
+	d.dateChosen.SetText(str)
 }

--- a/cmd/calendar_demo/main.go
+++ b/cmd/calendar_demo/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	// Defines which date you would like the calendar to start
 	startingDate := time.Now()
-	calendar := xwidget.NewCalendar(startingDate, xwidget.CalendarSingle, d.onChanged)
+	calendar := xwidget.NewCalendar(startingDate, d.onChanged)
 
 	selection := widget.NewRadioGroup([]string{"Single", "Multi", "Range"}, func(s string) {
 		calendar.ClearSelection()

--- a/widget/calendar.go
+++ b/widget/calendar.go
@@ -432,10 +432,10 @@ func (c *Calendar) CreateRenderer() fyne.WidgetRenderer {
 }
 
 // NewCalendar creates a calendar instance
-func NewCalendar(cT time.Time, selectionMode int, onChanged func([]time.Time)) *Calendar {
+func NewCalendar(cT time.Time, onChanged func([]time.Time)) *Calendar {
 	c := &Calendar{
 		currentTime:   cT,
-		SelectionMode: selectionMode,
+		SelectionMode: CalendarSingle,
 		OnChanged:     onChanged,
 	}
 

--- a/widget/calendar.go
+++ b/widget/calendar.go
@@ -1,7 +1,9 @@
 package widget
 
 import (
+	"errors"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -17,8 +19,14 @@ import (
 var _ fyne.Layout = (*calendarLayout)(nil)
 
 const (
-	daysPerWeek      = 7
-	maxWeeksPerMonth = 6
+	daysPerWeek           = 7
+	maxWeeksPerMonth      = 6
+	calendarSelectColor   = widget.HighImportance
+	calendarUnselectColor = widget.LowImportance
+
+	CalendarSingle = iota
+	CalendarMulti  = iota
+	CalendarRange  = iota
 )
 
 type calendarLayout struct {
@@ -104,7 +112,9 @@ type Calendar struct {
 
 	dates *fyne.Container
 
-	onSelected func(time.Time)
+	SelectionMode int
+	SelectedDates []time.Time
+	OnChanged     func([]time.Time)
 }
 
 func (c *Calendar) daysOfMonth() []fyne.CanvasObject {
@@ -122,19 +132,239 @@ func (c *Calendar) daysOfMonth() []fyne.CanvasObject {
 		buttons = append(buttons, layout.NewSpacer())
 	}
 
+	currentMonth := start.Month()
+	currentYear := start.Year()
+	// Stores all buttons of the current month
+	dateButtons := []*widget.Button{nil}
+
 	for d := start; d.Month() == start.Month(); d = d.AddDate(0, 0, 1) {
 
 		dayNum := d.Day()
 		s := strconv.Itoa(dayNum)
-		b := widget.NewButton(s, func() {
+		var b *widget.Button
+		b = widget.NewButton(s, func() {
 
 			selectedDate := c.dateForButton(dayNum)
 
-			c.onSelected(selectedDate)
+			if c.SelectionMode == CalendarSingle {
+				// Unselect all currently selected buttons
+				isSelected := false
+				for _, t := range c.SelectedDates {
+					tYear, tMonth, tDay := t.Date()
+
+					if tYear == currentYear && tMonth == currentMonth {
+						dateButtons[tDay].Importance = calendarUnselectColor
+						dateButtons[tDay].Refresh()
+						if tDay == dayNum {
+							isSelected = true
+						}
+					}
+				}
+
+				// Toggle the selection of a button
+				if !isSelected {
+					c.SelectedDates = []time.Time{selectedDate}
+					b.Importance = calendarSelectColor
+					b.Refresh()
+				} else {
+					c.SelectedDates = c.SelectedDates[:0]
+				}
+			} else if c.SelectionMode == CalendarMulti {
+				// Only add it to the slice if it does not contain it
+				index := math.MaxInt
+				for i, t := range c.SelectedDates {
+					if dateEquals(t, selectedDate) {
+						index = i
+						break
+					}
+				}
+
+				if index == math.MaxInt {
+					c.SelectedDates = append(c.SelectedDates, selectedDate)
+					b.Importance = calendarSelectColor
+				} else {
+					c.SelectedDates = append(c.SelectedDates[:index], c.SelectedDates[index+1:]...)
+					b.Importance = calendarUnselectColor
+				}
+
+				// Sort the dates
+				sort.Sort(&dateSort{c.SelectedDates})
+
+				b.Refresh()
+			} else if c.SelectionMode == CalendarRange {
+				if len(c.SelectedDates) == 0 {
+					sDay := selectedDate.Day()
+					dateButtons[sDay].Importance = calendarSelectColor
+					dateButtons[sDay].Refresh()
+
+					c.SelectedDates = append(c.SelectedDates, selectedDate)
+				} else if len(c.SelectedDates) == 1 {
+					if dateEquals(c.SelectedDates[0], selectedDate) {
+						sDay := selectedDate.Day()
+						dateButtons[sDay].Importance = calendarUnselectColor
+						dateButtons[sDay].Refresh()
+
+						c.SelectedDates = c.SelectedDates[:0]
+					} else {
+						var beginDate, endDate time.Time
+
+						if c.SelectedDates[0].Before(selectedDate) {
+							beginDate = c.SelectedDates[0]
+							endDate = selectedDate
+						} else {
+							beginDate = selectedDate
+							endDate = c.SelectedDates[0]
+						}
+
+						// Add all other dates in between the beginning and the end
+						var allDates []time.Time
+						for t := beginDate; !dateEquals(t, endDate); t = t.AddDate(0, 0, 1) {
+							tYear, tMonth, tDay := t.Date()
+							if tYear == currentYear && tMonth == currentMonth {
+								dateButtons[tDay].Importance = calendarSelectColor
+								dateButtons[tDay].Refresh()
+							}
+
+							allDates = append(allDates, t)
+						}
+						allDates = append(allDates, endDate)
+
+						eYear, eMonth, eDay := endDate.Date()
+						if eYear == currentYear && eMonth == currentMonth {
+							dateButtons[eDay].Importance = calendarSelectColor
+							dateButtons[eDay].Refresh()
+						}
+
+						c.SelectedDates = allDates
+					}
+				} else {
+					if dateEquals(c.SelectedDates[0], selectedDate) {
+						// Clear the entire selection except for the last
+						for _, t := range c.SelectedDates[:len(c.SelectedDates)-1] {
+							tYear, tMonth, tDay := t.Date()
+							if tYear == currentYear && tMonth == currentMonth {
+								dateButtons[tDay].Importance = calendarUnselectColor
+								dateButtons[tDay].Refresh()
+							}
+						}
+
+						c.SelectedDates = []time.Time{c.SelectedDates[len(c.SelectedDates)-1]}
+					} else if dateEquals(c.SelectedDates[len(c.SelectedDates)-1], selectedDate) {
+						// Clear the entire selection except for the first
+						for _, t := range c.SelectedDates[1:] {
+							tYear, tMonth, tDay := t.Date()
+							if tYear == currentYear && tMonth == currentMonth {
+								dateButtons[tDay].Importance = calendarUnselectColor
+								dateButtons[tDay].Refresh()
+							}
+						}
+
+						c.SelectedDates = []time.Time{c.SelectedDates[0]}
+					} else if c.SelectedDates[0].Before(selectedDate) && selectedDate.Before(c.SelectedDates[len(c.SelectedDates)-1]) {
+						// If a date between the start and end is clicked
+
+						index := math.MaxInt
+						for i, t := range c.SelectedDates {
+							if dateEquals(t, selectedDate) {
+								index = i
+								break
+							}
+						}
+
+						// Should not happen
+						if index == math.MaxInt {
+							fyne.LogError("Calendar", errors.New("index of selected date could not be found in the selected dates of the calendar"))
+							return
+						}
+
+						// Wether the selected date is closer to the start or end of the range
+						if selectedDate.Sub(c.SelectedDates[0]) < c.SelectedDates[len(c.SelectedDates)-1].Sub(selectedDate) {
+							// Change the start to the current one
+							for _, t := range c.SelectedDates[:index] {
+								tYear, tMonth, tDay := t.Date()
+								if tYear == currentYear && tMonth == currentMonth {
+									dateButtons[tDay].Importance = calendarUnselectColor
+									dateButtons[tDay].Refresh()
+								}
+							}
+
+							c.SelectedDates = c.SelectedDates[index:]
+						} else {
+							// Change the end to the current one
+							for _, t := range c.SelectedDates[index+1:] {
+								tYear, tMonth, tDay := t.Date()
+								if tYear == currentYear && tMonth == currentMonth {
+									dateButtons[tDay].Importance = calendarUnselectColor
+									dateButtons[tDay].Refresh()
+								}
+							}
+
+							c.SelectedDates = c.SelectedDates[:index+1]
+						}
+					} else {
+						// if a date outside start and end is clicked
+
+						if selectedDate.Before(c.SelectedDates[0]) {
+							// Change the start to the current one
+							for t := c.SelectedDates[0].AddDate(0, 0, -1); !dateEquals(t, selectedDate); t = t.AddDate(0, 0, -1) {
+								tYear, tMonth, tDay := t.Date()
+								if tYear == currentYear && tMonth == currentMonth {
+									dateButtons[tDay].Importance = calendarSelectColor
+									dateButtons[tDay].Refresh()
+								}
+
+								c.SelectedDates = append([]time.Time{t}, c.SelectedDates...)
+							}
+
+							sDay := selectedDate.Day()
+							dateButtons[sDay].Importance = calendarSelectColor
+							dateButtons[sDay].Refresh()
+
+							c.SelectedDates = append([]time.Time{selectedDate}, c.SelectedDates...)
+						} else {
+							// Change the end to the current one
+							for t := c.SelectedDates[len(c.SelectedDates)-1].AddDate(0, 0, 1); !dateEquals(t, selectedDate); t = t.AddDate(0, 0, 1) {
+								tYear, tMonth, tDay := t.Date()
+								if tYear == currentYear && tMonth == currentMonth {
+									dateButtons[tDay].Importance = calendarSelectColor
+									dateButtons[tDay].Refresh()
+								}
+
+								c.SelectedDates = append(c.SelectedDates, t)
+							}
+
+							sDay := selectedDate.Day()
+							dateButtons[sDay].Importance = calendarSelectColor
+							dateButtons[sDay].Refresh()
+
+							c.SelectedDates = append(c.SelectedDates, selectedDate)
+						}
+					}
+				}
+			}
+
+			if c.OnChanged != nil {
+				c.OnChanged(c.SelectedDates)
+			}
 		})
-		b.Importance = widget.LowImportance
+
+		// Give the selected dates a different importance
+		isSelected := false
+		for _, t := range c.SelectedDates {
+			if dateEquals(t, d) {
+				isSelected = true
+				break
+			}
+		}
+
+		if isSelected {
+			b.Importance = calendarSelectColor
+		} else {
+			b.Importance = calendarUnselectColor
+		}
 
 		buttons = append(buttons, b)
+		dateButtons = append(dateButtons, b)
 	}
 
 	return buttons
@@ -198,13 +428,81 @@ func (c *Calendar) CreateRenderer() fyne.WidgetRenderer {
 }
 
 // NewCalendar creates a calendar instance
-func NewCalendar(cT time.Time, onSelected func(time.Time)) *Calendar {
+func NewCalendar(cT time.Time, selectionMode int, onChanged func([]time.Time)) *Calendar {
 	c := &Calendar{
-		currentTime: cT,
-		onSelected:  onSelected,
+		currentTime:   cT,
+		SelectionMode: selectionMode,
+		OnChanged:     onChanged,
 	}
 
 	c.ExtendBaseWidget(c)
 
 	return c
+}
+
+func (c *Calendar) ClearSelection() {
+	c.SelectedDates = c.SelectedDates[:0]
+
+	for _, d := range c.dates.Objects {
+		if b, ok := d.(*widget.Button); ok {
+			b.Importance = calendarUnselectColor
+		}
+	}
+
+	if c.OnChanged != nil {
+		c.OnChanged(c.SelectedDates)
+	}
+}
+
+func (c *Calendar) Refresh() {
+	cYear, cMonth, _ := c.currentTime.Date()
+
+	// Color the date buttons according to the selected dates
+	for _, d := range c.dates.Objects {
+		if b, ok := d.(*widget.Button); ok {
+			day, err := strconv.Atoi(b.Text)
+			if err != nil {
+				continue
+			}
+
+			isSelected := false
+			for _, t := range c.SelectedDates {
+				tYear, tMonth, tDay := t.Date()
+				if tDay == day && tMonth == cMonth && tYear == cYear {
+					isSelected = true
+					break
+				}
+			}
+
+			if isSelected {
+				b.Importance = calendarSelectColor
+			} else {
+				b.Importance = calendarUnselectColor
+			}
+		}
+	}
+
+	c.BaseWidget.Refresh()
+}
+
+type dateSort struct {
+	dates []time.Time
+}
+
+func (d *dateSort) Len() int {
+	return len(d.dates)
+}
+
+func (d *dateSort) Less(i, j int) bool {
+	return d.dates[i].Before(d.dates[j])
+}
+
+func (d *dateSort) Swap(i, j int) {
+	d.dates[i], d.dates[j] = d.dates[j], d.dates[i]
+}
+
+func dateEquals(t1, t2 time.Time) bool {
+	d1, m1, y1 := t1.Date()
+	d2, m2, y2 := t2.Date()
+	return d1 == d2 && m1 == m2 && y1 == y2
 }

--- a/widget/calendar.go
+++ b/widget/calendar.go
@@ -171,15 +171,17 @@ func (c *Calendar) daysOfMonth() []fyne.CanvasObject {
 				}
 			} else if c.SelectionMode == CalendarMulti {
 				// Only add it to the slice if it does not contain it
-				index := math.MaxInt
+				var index int
+				var found bool
 				for i, t := range c.SelectedDates {
 					if dateEquals(t, selectedDate) {
 						index = i
+						found = true
 						break
 					}
 				}
 
-				if index == math.MaxInt {
+				if !found {
 					c.SelectedDates = append(c.SelectedDates, selectedDate)
 					b.Importance = calendarSelectColor
 				} else {
@@ -263,16 +265,18 @@ func (c *Calendar) daysOfMonth() []fyne.CanvasObject {
 					} else if c.SelectedDates[0].Before(selectedDate) && selectedDate.Before(c.SelectedDates[len(c.SelectedDates)-1]) {
 						// If a date between the start and end is clicked
 
-						index := math.MaxInt
+						var index int
+						var found bool
 						for i, t := range c.SelectedDates {
 							if dateEquals(t, selectedDate) {
 								index = i
+								found = true
 								break
 							}
 						}
 
 						// Should not happen
-						if index == math.MaxInt {
+						if !found {
 							fyne.LogError("Calendar", errors.New("index of selected date could not be found in the selected dates of the calendar"))
 							return
 						}

--- a/widget/calendar_test.go
+++ b/widget/calendar_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewCalendar(t *testing.T) {
 	now := time.Now()
-	c := NewCalendar(now, func(time.Time) {})
+	c := NewCalendar(now, CalendarSingle, nil)
 	assert.Equal(t, now.Day(), c.currentTime.Day())
 	assert.Equal(t, int(now.Month()), int(c.currentTime.Month()))
 	assert.Equal(t, now.Year(), c.currentTime.Year())
@@ -25,7 +25,7 @@ func TestNewCalendar(t *testing.T) {
 
 func TestNewCalendar_ButtonDate(t *testing.T) {
 	date := time.Now()
-	c := NewCalendar(date, func(time.Time) {})
+	c := NewCalendar(date, CalendarSingle, nil)
 	_ = test.WidgetRenderer(c) // and render
 
 	endNextMonth := date.AddDate(0, 1, 0).AddDate(0, 0, -(date.Day() - 1))
@@ -39,7 +39,7 @@ func TestNewCalendar_ButtonDate(t *testing.T) {
 
 func TestNewCalendar_Next(t *testing.T) {
 	date := time.Now()
-	c := NewCalendar(date, func(time.Time) {})
+	c := NewCalendar(date, CalendarSingle, nil)
 	_ = test.WidgetRenderer(c) // and render
 
 	assert.Equal(t, date.Format("January 2006"), c.monthLabel.Text)
@@ -51,7 +51,7 @@ func TestNewCalendar_Next(t *testing.T) {
 
 func TestNewCalendar_Previous(t *testing.T) {
 	date := time.Now()
-	c := NewCalendar(date, func(time.Time) {})
+	c := NewCalendar(date, CalendarSingle, nil)
 	_ = test.WidgetRenderer(c) // and render
 
 	assert.Equal(t, date.Format("January 2006"), c.monthLabel.Text)
@@ -82,6 +82,134 @@ func TestNewCalendar_Resize(t *testing.T) {
 	r.Layout(baseSize.AddWidthHeight(100, 100))
 	assert.Greater(t, layout.cellSize.Width, min.Width)
 	assert.Greater(t, layout.cellSize.Height, min.Height)
+}
+
+func TestNewCalendar_Single(t *testing.T) {
+	date := time.Date(2023, time.June, 22, 13, 48, 45, 0, time.UTC)
+	c := NewCalendar(date, CalendarSingle, nil)
+	_ = test.WidgetRenderer(c) // and render
+
+	btn := getDateButton(c.dates, 14)
+	test.Tap(btn)
+
+	assert.Equal(t, widget.HighImportance, btn.Importance)
+	if assert.Len(t, c.SelectedDates, 1) {
+		tYear, tMonth, tDay := c.SelectedDates[0].Date()
+		assert.Equal(t, 2023, tYear)
+		assert.Equal(t, time.June, tMonth)
+		assert.Equal(t, 14, tDay)
+	}
+
+	test.Tap(btn)
+
+	assert.Equal(t, widget.LowImportance, btn.Importance)
+	assert.Empty(t, c.SelectedDates)
+}
+
+func TestNewCalendar_Multi(t *testing.T) {
+	date := time.Date(2023, time.June, 22, 13, 48, 45, 0, time.UTC)
+	c := NewCalendar(date, CalendarMulti, nil)
+	_ = test.WidgetRenderer(c) // and render
+
+	test.Tap(getDateButton(c.dates, 4))
+	test.Tap(getDateButton(c.dates, 10))
+	test.Tap(getDateButton(c.dates, 3))
+	test.Tap(getDateButton(c.dates, 9))
+
+	if assert.Len(t, c.SelectedDates, 4) {
+		y, m, d := c.SelectedDates[0].Date()
+		assert.Equal(t, 2023, y)
+		assert.Equal(t, time.June, m)
+		assert.Equal(t, 3, d)
+
+		y, m, d = c.SelectedDates[1].Date()
+		assert.Equal(t, 2023, y)
+		assert.Equal(t, time.June, m)
+		assert.Equal(t, 4, d)
+
+		y, m, d = c.SelectedDates[2].Date()
+		assert.Equal(t, 2023, y)
+		assert.Equal(t, time.June, m)
+		assert.Equal(t, 9, d)
+
+		y, m, d = c.SelectedDates[3].Date()
+		assert.Equal(t, 2023, y)
+		assert.Equal(t, time.June, m)
+		assert.Equal(t, 10, d)
+	}
+
+	test.Tap(getDateButton(c.dates, 3))
+
+	assert.Len(t, c.SelectedDates, 3)
+
+	assert.Equal(t, widget.LowImportance, getDateButton(c.dates, 3).Importance)
+	assert.Equal(t, widget.HighImportance, getDateButton(c.dates, 4).Importance)
+	assert.Equal(t, widget.HighImportance, getDateButton(c.dates, 9).Importance)
+	assert.Equal(t, widget.HighImportance, getDateButton(c.dates, 10).Importance)
+}
+
+func TestNewCalendar_Range(t *testing.T) {
+	date := time.Date(2023, time.June, 22, 13, 48, 45, 0, time.UTC)
+	c := NewCalendar(date, CalendarRange, nil)
+	_ = test.WidgetRenderer(c) // and render
+
+	test.Tap(getDateButton(c.dates, 5))
+	test.Tap(getDateButton(c.dates, 20))
+
+	for i := 5; i <= 20; i++ {
+		assert.Equal(t, widget.HighImportance, getDateButton(c.dates, i).Importance)
+	}
+
+	if assert.Len(t, c.SelectedDates, 16) {
+		for i, s := range c.SelectedDates {
+			y, m, d := s.Date()
+			assert.Equal(t, 2023, y)
+			assert.Equal(t, time.June, m)
+			assert.Equal(t, i+5, d)
+		}
+	}
+
+	test.Tap(getDateButton(c.dates, 7))
+
+	assert.Len(t, c.SelectedDates, 14)
+	assert.Equal(t, 7, c.SelectedDates[0].Day())
+
+	test.Tap(getDateButton(c.dates, 19))
+
+	assert.Len(t, c.SelectedDates, 13)
+	assert.Equal(t, 19, c.SelectedDates[len(c.SelectedDates)-1].Day())
+
+	test.Tap(getDateButton(c.dates, 7))
+	assert.Len(t, c.SelectedDates, 1)
+	assert.Equal(t, 19, c.SelectedDates[0].Day())
+
+	test.Tap(getDateButton(c.dates, 7))
+	test.Tap(getDateButton(c.dates, 4))
+
+	assert.Len(t, c.SelectedDates, 16)
+	assert.Equal(t, 4, c.SelectedDates[0].Day())
+
+	test.Tap(getDateButton(c.dates, 21))
+	assert.Len(t, c.SelectedDates, 18)
+	assert.Equal(t, 21, c.SelectedDates[len(c.SelectedDates)-1].Day())
+
+	test.Tap(getDateButton(c.dates, 21))
+	assert.Len(t, c.SelectedDates, 1)
+	assert.Equal(t, 4, c.SelectedDates[0].Day())
+}
+
+func getDateButton(c *fyne.Container, day int) *widget.Button {
+	var counter int
+	for _, b := range c.Objects {
+		if nonBlank, ok := b.(*widget.Button); ok {
+			if counter+1 == day {
+				return nonBlank
+			}
+			counter++
+		}
+	}
+
+	return nil
 }
 
 func firstDateButton(c *fyne.Container) *widget.Button {

--- a/widget/calendar_test.go
+++ b/widget/calendar_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewCalendar(t *testing.T) {
 	now := time.Now()
-	c := NewCalendar(now, CalendarSingle, nil)
+	c := NewCalendar(now, nil)
 	assert.Equal(t, now.Day(), c.currentTime.Day())
 	assert.Equal(t, int(now.Month()), int(c.currentTime.Month()))
 	assert.Equal(t, now.Year(), c.currentTime.Year())
@@ -25,7 +25,7 @@ func TestNewCalendar(t *testing.T) {
 
 func TestNewCalendar_ButtonDate(t *testing.T) {
 	date := time.Now()
-	c := NewCalendar(date, CalendarSingle, nil)
+	c := NewCalendar(date, nil)
 	_ = test.WidgetRenderer(c) // and render
 
 	endNextMonth := date.AddDate(0, 1, 0).AddDate(0, 0, -(date.Day() - 1))
@@ -39,7 +39,7 @@ func TestNewCalendar_ButtonDate(t *testing.T) {
 
 func TestNewCalendar_Next(t *testing.T) {
 	date := time.Now()
-	c := NewCalendar(date, CalendarSingle, nil)
+	c := NewCalendar(date, nil)
 	_ = test.WidgetRenderer(c) // and render
 
 	assert.Equal(t, date.Format("January 2006"), c.monthLabel.Text)
@@ -51,7 +51,7 @@ func TestNewCalendar_Next(t *testing.T) {
 
 func TestNewCalendar_Previous(t *testing.T) {
 	date := time.Now()
-	c := NewCalendar(date, CalendarSingle, nil)
+	c := NewCalendar(date, nil)
 	_ = test.WidgetRenderer(c) // and render
 
 	assert.Equal(t, date.Format("January 2006"), c.monthLabel.Text)
@@ -86,7 +86,7 @@ func TestNewCalendar_Resize(t *testing.T) {
 
 func TestNewCalendar_Single(t *testing.T) {
 	date := time.Date(2023, time.June, 22, 13, 48, 45, 0, time.UTC)
-	c := NewCalendar(date, CalendarSingle, nil)
+	c := NewCalendar(date, nil)
 	_ = test.WidgetRenderer(c) // and render
 
 	btn := getDateButton(c.dates, 14)
@@ -108,7 +108,8 @@ func TestNewCalendar_Single(t *testing.T) {
 
 func TestNewCalendar_Multi(t *testing.T) {
 	date := time.Date(2023, time.June, 22, 13, 48, 45, 0, time.UTC)
-	c := NewCalendar(date, CalendarMulti, nil)
+	c := NewCalendar(date, nil)
+	c.SelectionMode = CalendarMulti
 	_ = test.WidgetRenderer(c) // and render
 
 	test.Tap(getDateButton(c.dates, 4))
@@ -150,7 +151,8 @@ func TestNewCalendar_Multi(t *testing.T) {
 
 func TestNewCalendar_Range(t *testing.T) {
 	date := time.Date(2023, time.June, 22, 13, 48, 45, 0, time.UTC)
-	c := NewCalendar(date, CalendarRange, nil)
+	c := NewCalendar(date, nil)
+	c.SelectionMode = CalendarRange
 	_ = test.WidgetRenderer(c) // and render
 
 	test.Tap(getDateButton(c.dates, 5))


### PR DESCRIPTION
This PR adds different modes of selection to the calendar.

+ CalendarSingle
This is the same as the current mode. Only one date can be selected at once.
+ CalendarMulti
Multiple random dates can be selected at the same time
+ CalendarRange
Select a beginning and end to select all dates in between those dates.

To achieve this change some compatibility breaking changes had to be made:

1. `SelectedDates` field has beend added to the calendar struct
Here all dates that the user will select are stored no matter what mode has been chosen. This can also be freely manipulated as it is an exported field. When calling `Refresh` the display is updated.
2. ~~`OnSelected` has been replaced by `OnChanged`~~ `OnChanged` has been added as a callback for the new modes
The `OnChanged` callback is now called everytime the user presses a button and the selected dates are changed. While `OnSelected` is called with the clicked date if the date is part of the selected dates.
3. Selected date buttons are highlighted using the HighImportance
Since there isn't another way to give buttons custom colors right now. I used the Importance system to signal the user which dates have been selected. And if a button is not selected it uses the previous LowImportance.

This also takes care of #54

