### PR TITLE
Fix responsive

### DIFF
--- a/cmd/responsive_layout/main.go
+++ b/cmd/responsive_layout/main.go
@@ -28,15 +28,15 @@ func main() {
 		winSizeLabel(window), // 100% by default
 		layout.Responsive(
 			widget.NewButton("One !", func() {}),
-			1, .33,
+			1, 1.0/3.0,
 		),
 		layout.Responsive(
 			widget.NewButton("Two !", func() {}),
-			1, .33,
+			1, 1.0/3.0,
 		),
 		layout.Responsive(
 			widget.NewButton("Three !", func() {}),
-			1, .34,
+			1, 1.0/3.0,
 		),
 		layout.Responsive(fromLayout(), 1, .5), // 100% for small, 50% for others
 		layout.Responsive(fromLayout(), 1, .5), // 100% for small, 50% for others

--- a/cmd/responsive_layout/main.go
+++ b/cmd/responsive_layout/main.go
@@ -28,15 +28,15 @@ func main() {
 		winSizeLabel(window), // 100% by default
 		layout.Responsive(
 			widget.NewButton("One !", func() {}),
-			1, 1.0/3.0,
+			1, layout.OneThird,
 		),
 		layout.Responsive(
 			widget.NewButton("Two !", func() {}),
-			1, 1.0/3.0,
+			1, layout.OneThird,
 		),
 		layout.Responsive(
 			widget.NewButton("Three !", func() {}),
-			1, 1.0/3.0,
+			1, layout.OneThird,
 		),
 		layout.Responsive(fromLayout(), 1, .5), // 100% for small, 50% for others
 		layout.Responsive(fromLayout(), 1, .5), // 100% for small, 50% for others

--- a/layout/responsive_test.go
+++ b/layout/responsive_test.go
@@ -50,8 +50,8 @@ func TestResponsive_Responsive(t *testing.T) {
 	win.Resize(fyne.NewSize(w, h))
 	size1 := label1.Size()
 	size2 := label2.Size()
-	assert.Equal(t, w-padding*2, size1.Width)
-	assert.Equal(t, w-padding*2, size2.Width)
+	assert.Equal(t, size1.Width, size2.Width)
+	assert.Equal(t, w-padding*3, size1.Width)
 
 	// Then resize to w > SMALL so the labels should be sized to 50% of the layout
 	w = float32(MEDIUM)
@@ -85,8 +85,11 @@ func TestResponsive_GoToNextLine(t *testing.T) {
 	assert.NotEqual(t, label1.Position().Y, label3.Position().Y)
 
 	// just to be sure...
-	// the label3 should be at label1.Position().Y + label1.Size().Height
-	assert.Equal(t, label1.Position().Y+label1.Size().Height, label3.Position().Y)
+	// the label3 should be at label1.Position().Y + label1.Size().Height + theme.Padding()
+	assert.Equal(t,
+		label1.Position().Y+label1.Size().Height+theme.Padding(), // expected
+		label3.Position().Y, // actual
+	)
 }
 
 // Check if sizes are correctly computed for responsive widgets when the window size
@@ -111,36 +114,37 @@ func TestResponsive_SwitchAllSizes(t *testing.T) {
 	w = w - 2*p
 	for i := 0; i < n; i++ {
 		size := labels[i].Size()
-		assert.Equal(t, w, size.Width)
+		assert.Equal(t, w-p, size.Width)
 	}
 
 	// Then resize to w > SMALL so the labels should be sized to 50% of the layout
 	w = float32(MEDIUM)
 	win.Resize(fyne.NewSize(w, h))
-	w = w - 2*p
+	w = w/2 - 2*p
 	for i := 0; i < n; i++ {
 		size := labels[i].Size()
-		assert.Equal(t, w/2-p, size.Width) // 1 padding between 2 widgets
+		assert.Equal(t, w, size.Width) // 1 padding between 2 widgets
 	}
 
 	// Then resize to w > MEDIUM so the labels should be sized to 33% of the layout
 	w = float32(LARGE)
 	win.Resize(fyne.NewSize(w, h))
-	w = w - 2*p
-	for i := 0; i < n-1; i++ { // note: n-1 because the last element seems to be resized
+	w = w / 3
+	w = float32(math.Floor(float64(w))) - p - 2 // note: 2px are removed to avoid rounding errors
+	for i := 0; i < n-1; i++ {
 		size := labels[i].Size()
-		floor := math.Floor(float64(w)/3 - float64(p)/3)
-		assert.Equal(t, float32(floor), size.Width) // 2 paddings between 3 widgets
+		assert.Equal(t, w, size.Width) // 2 paddings between 3 widgets
 	}
 
 	// Then resize to w > LARGE so the labels should be sized to 25% of the layout
 	w = float32(XLARGE)
 	win.Resize(fyne.NewSize(w, h))
-	w = w - 2*p
+	w = w / 4
+	w = w - p*2 + 2 // note: 2px are added to avoid rounding errors
 	for i := 0; i < n; i++ {
 		size := labels[i].Size()
 		// note: 1px is added to the size to avoid rounding errors
-		assert.Equal(t, w/4-p/4-1, float32(math.Floor(float64(size.Width))))
+		assert.Equal(t, w, size.Width) // 3 paddings between 4 widgets
 	}
 }
 


### PR DESCRIPTION
- The padding were not respected between element in a line and stepping
  to the next line
- We now prefer move the first element in a row to the X padding, to
  avoid computation - the responsive behavior is to center elements in a
  row, so it must be OK
- We accept now that a non-responsive element is added to the container,
  it will be resized to the default 100% of the container width
- We previously use the window size to compute the reponsive element
  sizes. That's an error... The reponsivity should be set to the
  container size. That fixed now.