### PR TITLE
fix(completionentry): calculate max size and resize correctly 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/jsummers/gobmp v0.0.0-20151104160322-e2ba15ffa76e // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c // indirect
 	github.com/tevino/abool v1.2.0 // indirect
@@ -38,6 +39,7 @@ require (
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -223,7 +223,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
@@ -249,6 +248,8 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20200213170602-2833bce08e4c/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -715,8 +716,9 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/widget/completionentry.go
+++ b/widget/completionentry.go
@@ -146,8 +146,7 @@ type navigableList struct {
 }
 
 func newNavigableList(items []string, entry *widget.Entry, setTextFromMenu func(string), hide func(),
-	create func() fyne.CanvasObject, update func(id widget.ListItemID, object fyne.CanvasObject),
-) *navigableList {
+	create func() fyne.CanvasObject, update func(id widget.ListItemID, object fyne.CanvasObject)) *navigableList {
 	n := &navigableList{
 		entry:           entry,
 		selected:        -1,

--- a/widget/completionentry.go
+++ b/widget/completionentry.go
@@ -52,6 +52,15 @@ func (c *CompletionEntry) Refresh() {
 	}
 }
 
+// Resize sets a new size for a widget.
+// Note this should not be used if the widget is being managed by a Layout within a Container.
+func (c *CompletionEntry) Resize(size fyne.Size) {
+	c.Entry.Resize(size)
+	if c.popupMenu != nil {
+		c.popupMenu.Resize(c.maxSize())
+	}
+}
+
 // SetOptions set the completion list with itemList and update the view.
 func (c *CompletionEntry) SetOptions(itemList []string) {
 	c.Options = itemList
@@ -94,16 +103,17 @@ func (c *CompletionEntry) maxSize() fyne.Size {
 		c.itemHeight = c.navigableList.CreateItem().MinSize().Height
 	}
 
-	listheight := float32(len(c.Options))*(c.itemHeight+2*theme.Padding()+theme.SeparatorThicknessSize()) + 2*theme.Padding()
 	canvasSize := cnv.Size()
 	entrySize := c.Size()
-	if canvasSize.Height > listheight {
-		return fyne.NewSize(entrySize.Width, listheight)
+	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(c)
+	listHeight := float32(len(c.Options))*(c.itemHeight+2*theme.Padding()+theme.SeparatorThicknessSize()) + 2*theme.Padding()
+	maxHeight := canvasSize.Height - entryPos.Y - entrySize.Height - 2*theme.Padding()
+
+	if listHeight > maxHeight {
+		listHeight = maxHeight
 	}
 
-	return fyne.NewSize(
-		entrySize.Width,
-		canvasSize.Height-c.Position().Y-entrySize.Height-theme.InputBorderSize()-theme.Padding())
+	return fyne.NewSize(entrySize.Width, listHeight)
 }
 
 // calculate where the popup should appear
@@ -136,7 +146,8 @@ type navigableList struct {
 }
 
 func newNavigableList(items []string, entry *widget.Entry, setTextFromMenu func(string), hide func(),
-	create func() fyne.CanvasObject, update func(id widget.ListItemID, object fyne.CanvasObject)) *navigableList {
+	create func() fyne.CanvasObject, update func(id widget.ListItemID, object fyne.CanvasObject),
+) *navigableList {
 	n := &navigableList{
 		entry:           entry,
 		selected:        -1,

--- a/widget/completionentry_test.go
+++ b/widget/completionentry_test.go
@@ -48,9 +48,9 @@ func TestCompletionEntry_Custom(t *testing.T) {
 
 	entry.SetText("init")
 	scroll := test.WidgetRenderer(entry.navigableList).Objects()[0].(fyne.Widget)
-	list := test.WidgetRenderer(scroll).Objects()[0].(*fyne.Container).Objects[1].(fyne.Widget)
+	list := test.WidgetRenderer(scroll).Objects()[0].(*fyne.Container).Objects[0].(fyne.Widget)
 	item1 := test.WidgetRenderer(list).Objects()[1]
-	assert.Equal(t, "bar", item1.(*widget.Check).Text) // ensure the item is a Check not Label
+	assert.Equal(t, "foo", item1.(*widget.Check).Text) // ensure the item is a Check not Label
 }
 
 // Show the completion menu
@@ -103,7 +103,6 @@ func TestCompletionEntry_CursorPosition(t *testing.T) {
 	win.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeyReturn})
 
 	assert.Equal(t, 6, entry.CursorColumn)
-
 }
 
 // Hide the menu on Escape key.


### PR DESCRIPTION
The new max size calculation ensures the popup position is always below
the entry widget.

The addition of the Resize method ensures the popup is updated with the
rest of the widget upon resize.

Since now the popup doesn't go above the entry widget not all options
are rendered and the test had to be updated to select the first item as
the other ones are not visible

Before:
https://github.com/user-attachments/assets/baff9482-3543-4e8a-8e52-cdad1ef79dcc

After:
https://github.com/user-attachments/assets/981f6a41-7705-42d0-a075-555c65fc28df

