### PR TITLE
Allow negative numbers to be input to NumericalEntry widget.

### DIFF
--- a/widget/numerical_entry.go
+++ b/widget/numerical_entry.go
@@ -13,6 +13,8 @@ import (
 type NumericalEntry struct {
 	widget.Entry
 	AllowFloat bool
+	// AllowNegative determines if negative numbers can be entered.
+	AllowNegative bool
 }
 
 // NewNumericalEntry returns an extended entry that only allows numerical input.
@@ -36,7 +38,7 @@ func (e *NumericalEntry) TypedRune(r rune) {
 		return
 	}
 
-	if r == '-' && e.Entry.CursorRow == 0 && e.Entry.CursorColumn == 0 {
+	if r == '-' && e.AllowNegative && e.Entry.CursorRow == 0 && e.Entry.CursorColumn == 0 {
 		e.Entry.TypedRune(r)
 	}
 }

--- a/widget/numerical_entry.go
+++ b/widget/numerical_entry.go
@@ -28,9 +28,15 @@ func NewNumericalEntry() *NumericalEntry {
 //
 // Implements: fyne.Focusable
 func (e *NumericalEntry) TypedRune(r rune) {
-	if e.Entry.CursorColumn == 0 && e.Entry.CursorRow == 0 &&
-		len(e.Entry.Text) > 0 && e.Entry.Text[0] == '-' {
-		return
+	if e.Entry.CursorColumn == 0 && e.Entry.CursorRow == 0 {
+		if e.AllowNegative {
+			if len(e.Text) > 0 && e.Text[0] == '-' {
+				return
+			} else if r == '-' {
+				e.Entry.TypedRune(r)
+				return
+			}
+		}
 	}
 
 	if r >= '0' && r <= '9' {
@@ -41,10 +47,6 @@ func (e *NumericalEntry) TypedRune(r rune) {
 	if e.AllowFloat && (r == '.' || r == ',') {
 		e.Entry.TypedRune(r)
 		return
-	}
-
-	if r == '-' && e.AllowNegative && e.Entry.CursorRow == 0 && e.Entry.CursorColumn == 0 {
-		e.Entry.TypedRune(r)
 	}
 }
 

--- a/widget/numerical_entry.go
+++ b/widget/numerical_entry.go
@@ -28,6 +28,11 @@ func NewNumericalEntry() *NumericalEntry {
 //
 // Implements: fyne.Focusable
 func (e *NumericalEntry) TypedRune(r rune) {
+	if e.Entry.CursorColumn == 0 && e.Entry.CursorRow == 0 &&
+		len(e.Entry.Text) > 0 && e.Entry.Text[0] == '-' {
+		return
+	}
+
 	if r >= '0' && r <= '9' {
 		e.Entry.TypedRune(r)
 		return

--- a/widget/numerical_entry.go
+++ b/widget/numerical_entry.go
@@ -33,6 +33,11 @@ func (e *NumericalEntry) TypedRune(r rune) {
 
 	if e.AllowFloat && (r == '.' || r == ',') {
 		e.Entry.TypedRune(r)
+		return
+	}
+
+	if r == '-' && e.Entry.CursorRow == 0 && e.Entry.CursorColumn == 0 {
+		e.Entry.TypedRune(r)
 	}
 }
 

--- a/widget/numerical_entry_test.go
+++ b/widget/numerical_entry_test.go
@@ -29,3 +29,26 @@ func TestNumericalnEntry_Float(t *testing.T) {
 	test.Type(entry, number)
 	assert.Equal(t, number, entry.Text)
 }
+
+func TestNumericalEntry_NegInt(t *testing.T) {
+	entry := NewNumericalEntry()
+
+	test.Type(entry, "-2")
+	assert.Equal(t, "-2", entry.Text)
+
+	entry.Text = ""
+	test.Type(entry, "24-")
+	assert.Equal(t, "24", entry.Text)
+}
+
+func TestNumericalEntry_NegFloat(t *testing.T) {
+	entry := NewNumericalEntry()
+	entry.AllowFloat = true
+
+	test.Type(entry, "-2.4")
+	assert.Equal(t, "-2.4", entry.Text)
+
+	entry.Text = ""
+	test.Type(entry, "24.-5")
+	assert.Equal(t, "24.5", entry.Text)
+}

--- a/widget/numerical_entry_test.go
+++ b/widget/numerical_entry_test.go
@@ -16,6 +16,10 @@ func TestNumericalnEntry_Int(t *testing.T) {
 	number := "123456789"
 	test.Type(entry, number)
 	assert.Equal(t, number, entry.Text)
+
+	entry.CursorColumn = 0
+	test.Type(entry, "3")
+	assert.Equal(t, "3123456789", entry.Text)
 }
 
 func TestNumericalnEntry_Float(t *testing.T) {
@@ -28,6 +32,10 @@ func TestNumericalnEntry_Float(t *testing.T) {
 	number := "123.456789"
 	test.Type(entry, number)
 	assert.Equal(t, number, entry.Text)
+
+	entry.CursorColumn = 0
+	test.Type(entry, "3")
+	assert.Equal(t, "3123.456789", entry.Text)
 }
 
 func TestNumericalEntry_NegInt(t *testing.T) {
@@ -40,6 +48,13 @@ func TestNumericalEntry_NegInt(t *testing.T) {
 	entry.Text = ""
 	test.Type(entry, "24-")
 	assert.Equal(t, "24", entry.Text)
+	entry.CursorColumn = 0
+	test.Type(entry, "-")
+	assert.Equal(t, "-24", entry.Text)
+
+	entry.CursorColumn = 0
+	test.Type(entry, "4")
+	assert.Equal(t, "-24", entry.Text)
 }
 
 func TestNumericalEntry_NegFloat(t *testing.T) {
@@ -51,6 +66,15 @@ func TestNumericalEntry_NegFloat(t *testing.T) {
 	assert.Equal(t, "-2.4", entry.Text)
 
 	entry.Text = ""
-	test.Type(entry, "24.-5")
-	assert.Equal(t, "24.5", entry.Text)
+	test.Type(entry, "-24.-5")
+	assert.Equal(t, "-24.5", entry.Text)
+
+	entry.CursorColumn = 0
+	test.Type(entry, "-")
+	assert.Equal(t, "-24.5", entry.Text)
+
+	entry.CursorColumn = 0
+	test.Type(entry, "4")
+	assert.Equal(t, "-24.5", entry.Text)
+
 }

--- a/widget/numerical_entry_test.go
+++ b/widget/numerical_entry_test.go
@@ -20,6 +20,10 @@ func TestNumericalnEntry_Int(t *testing.T) {
 	entry.CursorColumn = 0
 	test.Type(entry, "3")
 	assert.Equal(t, "3123456789", entry.Text)
+
+	entry.CursorColumn = 0
+	test.Type(entry, "-4")
+	assert.Equal(t, "43123456789", entry.Text)
 }
 
 func TestNumericalnEntry_Float(t *testing.T) {
@@ -36,6 +40,10 @@ func TestNumericalnEntry_Float(t *testing.T) {
 	entry.CursorColumn = 0
 	test.Type(entry, "3")
 	assert.Equal(t, "3123.456789", entry.Text)
+
+	entry.CursorColumn = 0
+	test.Type(entry, "-4")
+	assert.Equal(t, "43123.456789", entry.Text)
 }
 
 func TestNumericalEntry_NegInt(t *testing.T) {

--- a/widget/numerical_entry_test.go
+++ b/widget/numerical_entry_test.go
@@ -32,6 +32,7 @@ func TestNumericalnEntry_Float(t *testing.T) {
 
 func TestNumericalEntry_NegInt(t *testing.T) {
 	entry := NewNumericalEntry()
+	entry.AllowNegative = true
 
 	test.Type(entry, "-2")
 	assert.Equal(t, "-2", entry.Text)
@@ -43,6 +44,7 @@ func TestNumericalEntry_NegInt(t *testing.T) {
 
 func TestNumericalEntry_NegFloat(t *testing.T) {
 	entry := NewNumericalEntry()
+	entry.AllowNegative = true
 	entry.AllowFloat = true
 
 	test.Type(entry, "-2.4")


### PR DESCRIPTION
This implements fix for issue #103: NumericalEntry widget does not accept negative values (i.e. throws '-' character away).