### PR TITLE
Upgrade CI to maintain itself thus unbreak CI

### DIFF
--- a/.github/workflows/platform_tests.yml
+++ b/.github/workflows/platform_tests.yml
@@ -9,16 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.19.x', 'stable']
+        go-version: ['', 'stable']
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1
+    - uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
+        go-version-file: 'go.mod'
 
     - name: Get dependencies
       run: >-
@@ -31,8 +32,7 @@ jobs:
         libx11-dev
         libxkbcommon-dev
         xorg-dev
-        xvfb
       if: ${{ runner.os == 'Linux' }}
 
     - name: Tests
-      run: go test "-test.benchtime" 10ms -tags ci ./...
+      run: go test -tags ci ./...

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - uses: WillAbides/setup-go-faster@v1
+    - uses: actions/setup-go@v5
       with:
         go-version: 'stable'
 
@@ -27,13 +27,12 @@ jobs:
         libgles2-mesa-dev
         libx11-dev
         xorg-dev
-        xvfb
 
     - name: Install analysis tools
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
         go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-        go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+        go install honnef.co/go/tools/cmd/staticcheck@latest
         go install github.com/mattn/goveralls@latest
 
     - name: Vet


### PR DESCRIPTION
This adds in the changes that we have in most other repos as well. Things should update themselves, builds are cached for faster speed and Staticcheck supports Go 1.24 cleanly. Don't run benchmarks as part of test either. 