### PR TITLE
Fix maxSize method to handle nil canvas case in ShowCompletion

### DIFF
--- a/widget/completionentry.go
+++ b/widget/completionentry.go
@@ -97,6 +97,9 @@ func (c *CompletionEntry) ShowCompletion() {
 // calculate the max size to make the popup to cover everything below the entry
 func (c *CompletionEntry) maxSize() fyne.Size {
 	cnv := fyne.CurrentApp().Driver().CanvasForObject(c)
+	if cnv == nil {
+		return fyne.NewSize(0, 0)
+	}
 
 	if c.itemHeight == 0 {
 		// set item height to cache


### PR DESCRIPTION
I’ve been maintaining this patch manually for several years. Without it, if an app tab contains a completion widget, entering data and then leaving the tab idle for around five minutes triggers garbage collection, which clears `cnv` and causes a crash when switching back to that tab.

I’ve reapplied this fix across many updates and have yet to encounter any negative side effects. Given its stability, I’d like to propose integrating it into the official repository so others can benefit without needing to patch it locally.