### PR TITLE
Fix a small misplacing x-y/w-h issue

### DIFF
--- a/layout/portion.go
+++ b/layout/portion.go
@@ -108,8 +108,8 @@ func (p *VPortion) Layout(objects []fyne.CanvasObject, size fyne.Size) {
 
 	for i, child := range objects {
 		height := float32(p.Portions[i]/sum) * height
-		child.Resize(fyne.NewSize(ypos, height))
-		child.Move(fyne.NewPos(ypos, 0))
+		child.Resize(fyne.NewSize(size.Width, height))
+		child.Move(fyne.NewPos(0, ypos))
 
 		ypos += height + padding
 	}


### PR DESCRIPTION
⚠️ Please check this carefully because I am new to Fyne and do not want to accidentally break something. I just wanted to help.

While testing some widgets and layouts, I noticed a possible issue where the `ypos` variable was being used at an x position.

Thank you 🙃