### PR TITLE
widget: make CompletionEntry.FocusGained overridable

### DIFF
--- a/widget/completionentry.go
+++ b/widget/completionentry.go
@@ -17,12 +17,28 @@ type CompletionEntry struct {
 
 	CustomCreate func() fyne.CanvasObject
 	CustomUpdate func(id widget.ListItemID, object fyne.CanvasObject)
+
+	impl fyne.Widget
 }
 
 // NewCompletionEntry creates a new CompletionEntry which creates a popup menu that responds to keystrokes to navigate through the items without losing the editing ability of the text input.
 func NewCompletionEntry(options []string) *CompletionEntry {
 	c := &CompletionEntry{Options: options}
 	c.ExtendBaseWidget(c)
+	return c
+}
+
+// ExtendBaseWidget is used by an extending widget to make use of CompletionEntry functionality.
+func (c *CompletionEntry) ExtendBaseWidget(wid fyne.Widget) {
+	c.impl = wid
+	c.Entry.ExtendBaseWidget(wid)
+}
+
+// super returns the extending widget if set, otherwise the CompletionEntry itself.
+func (c *CompletionEntry) super() fyne.Widget {
+	if c.impl != nil {
+		return c.impl
+	}
 	return c
 }
 
@@ -84,7 +100,7 @@ func (c *CompletionEntry) ShowCompletion() {
 		c.navigableList.UnselectAll()
 		c.navigableList.selected = -1
 	}
-	holder := fyne.CurrentApp().Driver().CanvasForObject(c)
+	holder := fyne.CurrentApp().Driver().CanvasForObject(c.super())
 
 	if c.popupMenu == nil {
 		c.popupMenu = widget.NewPopUp(c.navigableList, holder)
@@ -96,7 +112,7 @@ func (c *CompletionEntry) ShowCompletion() {
 
 // calculate the max size to make the popup to cover everything below the entry
 func (c *CompletionEntry) maxSize() fyne.Size {
-	cnv := fyne.CurrentApp().Driver().CanvasForObject(c)
+	cnv := fyne.CurrentApp().Driver().CanvasForObject(c.super())
 
 	if c.itemHeight == 0 {
 		// set item height to cache
@@ -105,7 +121,7 @@ func (c *CompletionEntry) maxSize() fyne.Size {
 
 	canvasSize := cnv.Size()
 	entrySize := c.Size()
-	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(c)
+	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(c.super())
 	listHeight := float32(len(c.Options))*(c.itemHeight+2*theme.Padding()+theme.SeparatorThicknessSize()) + 2*theme.Padding()
 	maxHeight := canvasSize.Height - entryPos.Y - entrySize.Height - 2*theme.Padding()
 
@@ -118,7 +134,7 @@ func (c *CompletionEntry) maxSize() fyne.Size {
 
 // calculate where the popup should appear
 func (c *CompletionEntry) popUpPos() fyne.Position {
-	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(c)
+	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(c.super())
 	return entryPos.Add(fyne.NewPos(0, c.Size().Height))
 }
 

--- a/widget/completionentry_test.go
+++ b/widget/completionentry_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/test"
 	"fyne.io/fyne/v2/widget"
 	"github.com/stretchr/testify/assert"
@@ -227,4 +228,35 @@ func TestCompletionEntry_DoubleSubmissionIssue(t *testing.T) {
 	assert.False(t, entry.popupMenu.Visible())
 	win.Canvas().Focused().TypedKey(&fyne.KeyEvent{Name: fyne.KeyReturn}) // OnSubmitted should be called
 	assert.True(t, submitted)
+}
+
+// focusCompletionEntry overrides FocusGained to show the completion menu.
+type focusCompletionEntry struct {
+	CompletionEntry
+}
+
+func (f *focusCompletionEntry) FocusGained() {
+	f.CompletionEntry.FocusGained()
+	f.ShowCompletion()
+}
+
+// When CompletionEntry is embedded, the popup must resolve its position against
+// the extending widget so it appears below the entry rather than at the origin.
+func TestCompletionEntry_SubclassFocusGained(t *testing.T) {
+	entry := &focusCompletionEntry{}
+	entry.Options = entryData
+	entry.ExtendBaseWidget(entry)
+
+	// Nest below a label so the entry's absolute position is non-zero.
+	win := test.NewWindow(container.NewVBox(widget.NewLabel("top"), entry))
+	win.Resize(fyne.NewSize(500, 300))
+	defer win.Close()
+
+	win.Canvas().Focus(entry)
+	assert.NotNil(t, entry.popupMenu)
+	assert.True(t, entry.popupMenu.Visible())
+
+	entryPos := fyne.CurrentApp().Driver().AbsolutePositionForObject(entry)
+	assert.Greater(t, entryPos.Y, float32(0))
+	assert.Equal(t, entryPos.Add(fyne.NewPos(0, entry.Size().Height)), entry.popUpPos())
 }


### PR DESCRIPTION
Lets a user subclass `CompletionEntry` and override `FocusGained` (the standard fyne way to react to focus) without breaking the completion popup.

The popup previously resolved its canvas and position against the embedded `CompletionEntry` value, which is not the object registered in the canvas when the widget is extended — so the lookup failed/mispositioned for subclasses. It now resolves against the extending widget recorded via `ExtendBaseWidget`, mirroring fyne's own `Select`/`SelectEntry` (which use `super()` for the same reason).

Adds `TestCompletionEntry_SubclassFocusGained` covering an embedded entry whose popup must appear below the entry rather than at the canvas origin.

Supersedes the earlier `OnFocusGained` callback approach in favour of idiomatic fyne subclassing.