### PR TITLE
widget: fix CompletionEntry index out of range on fast input

### DIFF
--- a/widget/completionentry.go
+++ b/widget/completionentry.go
@@ -184,13 +184,14 @@ func newNavigableList(items []string, entry *widget.Entry, setTextFromMenu func(
 			return widget.NewLabel("")
 		},
 		UpdateItem: func(i widget.ListItemID, o fyne.CanvasObject) {
+			if i >= len(n.items) {
+				return
+			}
 			if fn := n.customUpdate; fn != nil {
 				fn(i, o)
 				return
 			}
-			if i < len(n.items) {
-				o.(*widget.Label).SetText(n.items[i])
-			}
+			o.(*widget.Label).SetText(n.items[i])
 		},
 		OnSelected: func(id widget.ListItemID) {
 			if !n.navigating && id > -1 && id < len(n.items) {

--- a/widget/completionentry.go
+++ b/widget/completionentry.go
@@ -188,10 +188,12 @@ func newNavigableList(items []string, entry *widget.Entry, setTextFromMenu func(
 				fn(i, o)
 				return
 			}
-			o.(*widget.Label).SetText(n.items[i])
+			if i < len(n.items) {
+				o.(*widget.Label).SetText(n.items[i])
+			}
 		},
 		OnSelected: func(id widget.ListItemID) {
-			if !n.navigating && id > -1 {
+			if !n.navigating && id > -1 && id < len(n.items) {
 				setTextFromMenu(n.items[id])
 			}
 			n.navigating = false


### PR DESCRIPTION
## Summary

Fixes a panic (`index out of range`) that occurs when the user types quickly into a `CompletionEntry`.

## Changes

Add bounds checks in `UpdateItem` and `OnSelected` callbacks of `navigableList`. When options are replaced with a shorter slice while the list is mid-render, the list may call `UpdateItem` with an index that no longer exists. The guards silently skip stale renders instead of panicking.

## Testing

All existing `TestCompletionEntry*` tests pass. The fix is defensive: it tolerates the race without changing any observable behaviour in the non-racing path.

Fixes #38